### PR TITLE
Fix typos in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ services:
       TZ: "Europe/London"
       KIOSK_IMMICH_API_KEY: ""
       KIOSK_IMMICH_URL: ""
-      KIOSK_DISBALE_UI: FALSE
+      KIOSK_DISABLE_UI: FALSE
       KIOSK_SHOW_DATE: TRUE
       KIOSK_DATE_FORMAT: 02/01/2006
       KIOSK_SHOW_TIME: TRUE

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You want to have a slideshow of your Immmich images using the webpage card in Ho
 \* I would suggest disabling all the UI i.e. `http://192.168.0.123:3000?disable_ui=true`
 
 ### Example 2
-You have a two spare Raspberry Pi's laying around. One hooked up to a LCD screen and the other you connect to your TV. You install a fullscreen browser OS or service on them (I use [DeitPi][dietpi-url]).
+You have a two spare Raspberry Pi's laying around. One hooked up to a LCD screen and the other you connect to your TV. You install a fullscreen browser OS or service on them (I use [DietPi][dietpi-url]).
 
 You want the pi connected to the LCD screen to only show images from your recent holiday, which are stored in a album on Immich. It's an older pi so you want to disable CSS transitions, also we don't want to display the time of the image.
 


### PR DESCRIPTION
This commit renames `DISBALE_UI` to `DISABLE_UI` in the Docker Compose example of the `README`.