### PR TITLE
Added password parameter for basic authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ services:
       TZ: "Europe/London"
       KIOSK_IMMICH_API_KEY: "****"
       KIOSK_IMMICH_URL: "****"
+      KIOSK_PASSWORD: "****"
       KIOSK_DISABLE_UI: FALSE
       KIOSK_SHOW_DATE: TRUE
       KIOSK_DATE_FORMAT: 02/01/2006
@@ -137,6 +138,7 @@ See the file config.example.yaml for an example config file
 |-------------------|-------------------------|----------------------------|--------------------------------------------------------------------------------------------|
 | immich_url        | KIOSK_IMMICH_URL        | string                     | The URL of your Immich server. MUST include a port if one is needed e.g. `http://192.168.1.123:2283`. |
 | immich_api_key    | KIOSK_IMMICH_API_KEY    | string                     | The API for your Immich server.                                                            |
+| password          | KIOSK_PASSWORD          | string                     | If set, requests must contain the password in the GET parameters.                          |
 | disable_ui        | KIOSK_DISABLE_UI        | bool                       | A shortcut to set show_time, show_date, show_image_time and image_date_format to false.    |
 | show_time         | KIOSK_SHOW_TIME         | bool                       | Display clock.                                                                             |
 | time_format       | KIOSK_TIME_FORMAT       | 12 \| 24                   | Display clock time in either 12 hour or 24 hour format. Can either be 12 or 24.            |

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,6 +1,8 @@
 immich_api_key: ""
 immich_url: ""
 
+password: "1234" # omit or leave blank for passwordless access
+
 disable_ui: false # this is just a shortcut for all ui elements (show_time, show_date, show_image_time, show_image_date)
 
 show_time: true # true or false

--- a/config/config.go
+++ b/config/config.go
@@ -138,25 +138,11 @@ func (c *Config) Load() error {
 }
 
 // ConfigWithOverrides overwrites base config with ones supplied via URL queries
-func (c *Config) ConfigWithOverrides(queries url.Values) (Config, error) {
+func (c *Config) ConfigWithOverrides(queries url.Values) Config {
 
 	configWithOverrides := c
 
 	v := reflect.ValueOf(configWithOverrides).Elem()
-
-	if c.Password != "" {
-		log.Print("Configured password:", c.Password)
-
-		password := queries.Get("password")
-		if password == "" {
-			log.Error("tried to access without password")
-			return Config{}, errors.New("Password not set")
-		}
-		if c.Password != password {
-			log.Error("tried to access with incorrect password")
-			return Config{}, errors.New("Incorrect password")
-		}
-	}
 
 	// Loop through the queries and update struct fields
 	for key, values := range queries {
@@ -220,5 +206,23 @@ func (c *Config) ConfigWithOverrides(queries url.Values) (Config, error) {
 		}
 	}
 
-	return *configWithOverrides, nil
+	return *configWithOverrides
+}
+
+// CheckPassword checks if password is set and matches, only if a password is set in the config
+func (c *Config) CheckPassword(queries url.Values) error {
+	if c.Password != "" {
+		log.Print("Configured password:", c.Password)
+
+		password := queries.Get("password")
+		if password == "" {
+			log.Error("tried to access without password")
+			return errors.New("Password not set")
+		}
+		if c.Password != password {
+			log.Error("tried to access with incorrect password")
+			return errors.New("Incorrect password")
+		}
+	}
+	return nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -73,7 +73,7 @@ func TestPassword(t *testing.T) {
 
 	q.Add("Password", "1234")
 
-	_, err := c.ConfigWithOverrides(q)
+	err := c.CheckPassword(q)
 
 	if c.Password != originalPassword {
 		t.Errorf("Password field was allowed to be changed: %s", c.Password)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -60,6 +60,30 @@ func TestImmichUrlImmichApiKeyImmutability(t *testing.T) {
 	}
 }
 
+// TestPassword testing whether AuthCode is immutable and whether it is checked
+func TestPassword(t *testing.T) {
+
+	originalPassword := "123456"
+
+	c := Config{
+		Password: originalPassword,
+	}
+
+	q := url.Values{}
+
+	q.Add("Password", "1234")
+
+	_, err := c.ConfigWithOverrides(q)
+
+	if c.Password != originalPassword {
+		t.Errorf("Password field was allowed to be changed: %s", c.Password)
+	}
+
+	if err == nil {
+		t.Errorf("Password was not checked")
+	}
+}
+
 func TestImmichUrlImmichMulitplePerson(t *testing.T) {
 
 	c := Config{}

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -60,7 +60,14 @@ func Home(c echo.Context) error {
 	}
 
 	if len(queries) > 0 {
-		instanceConfig = instanceConfig.ConfigWithOverrides(queries)
+		instanceConfig, err = instanceConfig.ConfigWithOverrides(queries)
+		if err != nil {
+			return Render(
+				c,
+				http.StatusOK,
+				views.Error(views.ErrorData{Title: "Error", Message: err.Error()}),
+			)
+		}
 	}
 
 	log.Debug(requestId, "path", c.Request().URL.String(), "instanceConfig", instanceConfig)
@@ -99,7 +106,14 @@ func NewImage(c echo.Context) error {
 	}
 
 	if len(queries) > 0 {
-		instanceConfig = instanceConfig.ConfigWithOverrides(queries)
+		instanceConfig, err = instanceConfig.ConfigWithOverrides(queries)
+		if err != nil {
+			return Render(
+				c,
+				http.StatusOK,
+				views.Error(views.ErrorData{Title: "Error", Message: err.Error()}),
+			)
+		}
 	}
 
 	log.Debug(requestId, "path", c.Request().URL.String(), "config", instanceConfig)
@@ -224,7 +238,14 @@ func Clock(c echo.Context) error {
 	}
 
 	if len(queries) > 0 {
-		instanceConfig = instanceConfig.ConfigWithOverrides(queries)
+		instanceConfig, err = instanceConfig.ConfigWithOverrides(queries)
+		if err != nil {
+			return Render(
+				c,
+				http.StatusOK,
+				views.Error(views.ErrorData{Title: "Error", Message: err.Error()}),
+			)
+		}
 	}
 
 	log.Debug(requestId, "path", c.Request().URL.String(), "config", instanceConfig)

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -64,7 +64,7 @@ func Home(c echo.Context) error {
 		if err != nil {
 			return Render(
 				c,
-				http.StatusOK,
+				http.StatusUnauthorized,
 				views.Error(views.ErrorData{Title: "Error", Message: err.Error()}),
 			)
 		}
@@ -110,7 +110,7 @@ func NewImage(c echo.Context) error {
 		if err != nil {
 			return Render(
 				c,
-				http.StatusOK,
+				http.StatusUnauthorized,
 				views.Error(views.ErrorData{Title: "Error", Message: err.Error()}),
 			)
 		}
@@ -242,7 +242,7 @@ func Clock(c echo.Context) error {
 		if err != nil {
 			return Render(
 				c,
-				http.StatusOK,
+				http.StatusUnauthorized,
 				views.Error(views.ErrorData{Title: "Error", Message: err.Error()}),
 			)
 		}

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -59,15 +59,17 @@ func Home(c echo.Context) error {
 		log.Error("err combining queries", "err", err)
 	}
 
+	err = instanceConfig.CheckPassword(queries)
+	if err != nil {
+		return Render(
+			c,
+			http.StatusUnauthorized,
+			views.Error(views.ErrorData{Title: "Error", Message: err.Error()}),
+		)
+	}
+
 	if len(queries) > 0 {
-		instanceConfig, err = instanceConfig.ConfigWithOverrides(queries)
-		if err != nil {
-			return Render(
-				c,
-				http.StatusUnauthorized,
-				views.Error(views.ErrorData{Title: "Error", Message: err.Error()}),
-			)
-		}
+		instanceConfig = instanceConfig.ConfigWithOverrides(queries)
 	}
 
 	log.Debug(requestId, "path", c.Request().URL.String(), "instanceConfig", instanceConfig)
@@ -105,15 +107,17 @@ func NewImage(c echo.Context) error {
 		log.Error("err combining queries", "err", err)
 	}
 
+	err = instanceConfig.CheckPassword(queries)
+	if err != nil {
+		return Render(
+			c,
+			http.StatusUnauthorized,
+			views.Error(views.ErrorData{Title: "Error", Message: err.Error()}),
+		)
+	}
+
 	if len(queries) > 0 {
-		instanceConfig, err = instanceConfig.ConfigWithOverrides(queries)
-		if err != nil {
-			return Render(
-				c,
-				http.StatusUnauthorized,
-				views.Error(views.ErrorData{Title: "Error", Message: err.Error()}),
-			)
-		}
+		instanceConfig = instanceConfig.ConfigWithOverrides(queries)
 	}
 
 	log.Debug(requestId, "path", c.Request().URL.String(), "config", instanceConfig)
@@ -237,15 +241,17 @@ func Clock(c echo.Context) error {
 		log.Error("err combining queries", "err", err)
 	}
 
+	err = instanceConfig.CheckPassword(queries)
+	if err != nil {
+		return Render(
+			c,
+			http.StatusUnauthorized,
+			views.Error(views.ErrorData{Title: "Error", Message: err.Error()}),
+		)
+	}
+
 	if len(queries) > 0 {
-		instanceConfig, err = instanceConfig.ConfigWithOverrides(queries)
-		if err != nil {
-			return Render(
-				c,
-				http.StatusUnauthorized,
-				views.Error(views.ErrorData{Title: "Error", Message: err.Error()}),
-			)
-		}
+		instanceConfig = instanceConfig.ConfigWithOverrides(queries)
 	}
 
 	log.Debug(requestId, "path", c.Request().URL.String(), "config", instanceConfig)


### PR DESCRIPTION
Hi! First of all, congrats on the new baby! No rush for this PR :)

I want to set up Immich Kiosk at my parents' house, pulling images from the Immich server at mine. Since I want to expose Immich Kiosk to the internet, but not let just any random person access my URL and see personal photos, I need some sort of authentication. I tried authenticating via my reverse proxy, but then if the session expires I don't want my parents to need to re-authenticate.

So I added a `password` parameter that can be configured via the config file or env variable. If it is set, incoming GET requests must contain a matching `password` parameter in the query. Otherwise, the Kiosk server just shows an error.

I don't think this is *particularly* secure, as I didn't implement any kind of encryption, but it should at least be sufficient to avoid random requests.

I'm happy to make changes if you have any suggestions!