### PR TITLE
Add tag to enable fullscreen PWA on iOS

### DIFF
--- a/views/home.templ
+++ b/views/home.templ
@@ -106,6 +106,7 @@ templ Home(data PageData) {
 	<html lang="en">
 		<head>
 			<meta charset="UTF-8"/>
+			<meta name="apple-mobile-web-app-capable" content="yes">
 			<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 			<meta name="version" content={ data.KioskVersion }/>
 			<title>Immich Kiosk</title>


### PR DESCRIPTION
I don't have a lot of experience with web development, but based on [these docs](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html) it looks like adding a meta tag to the main page allows it to assume full screen when pinned to the home screen and launched as a PWA. 