### PR TITLE
Hide Country Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ services:
       KIOSK_IMAGE_DATE_FORMAT: YYYY-MM-DD
       KIOSK_SHOW_IMAGE_EXIF: FALSE
       KIOSK_SHOW_IMAGE_LOCATION: FALSE
+      KIOSK_HIDE_USA: FALSE
       KIOSK_SHOW_IMAGE_ID: FALSE
       # Kiosk settings
       KIOSK_WATCH_CONFIG: FALSE
@@ -231,7 +232,8 @@ See the file config.example.yaml for an example config file
 | [image_date_format](#date-format) | KIOSK_IMAGE_DATE_FORMAT | string                     | DD/MM/YYYY  | The format of the image date. default is day/month/year. See [date format](#date-format) for more information. |
 | show_image_exif                   | KIOSK_SHOW_IMAGE_EXIF   | bool                       | false       | Display image Fnumber, Shutter speed, focal length, ISO from METADATA (if available).      |
 | show_image_location               | KIOSK_SHOW_IMAGE_LOCATION | bool                     | false       | Display the image location from METADATA (if available).                                   |
-| show_image_id                     | KIOSK_SHOW_IMAGE_ID     | bool                       | false       | Display the image Immich ID.                                   |
+| hide_usa                          | KIOSK_HIDE_USA          | bool                       | false       | Hide USA when displaying image location                                                    |
+| show_image_id                     | KIOSK_SHOW_IMAGE_ID     | bool                       | false       | Display the image Immich ID.                                                               |
 
 
 ### Additional options

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ services:
       KIOSK_IMAGE_DATE_FORMAT: YYYY-MM-DD
       KIOSK_SHOW_IMAGE_EXIF: FALSE
       KIOSK_SHOW_IMAGE_LOCATION: FALSE
-      KIOSK_HIDE_USA: FALSE
+      KIOSK_HIDE_COUNTRIES: ""
       KIOSK_SHOW_IMAGE_ID: FALSE
       # Kiosk settings
       KIOSK_WATCH_CONFIG: FALSE
@@ -232,7 +232,7 @@ See the file config.example.yaml for an example config file
 | [image_date_format](#date-format) | KIOSK_IMAGE_DATE_FORMAT | string                     | DD/MM/YYYY  | The format of the image date. default is day/month/year. See [date format](#date-format) for more information. |
 | show_image_exif                   | KIOSK_SHOW_IMAGE_EXIF   | bool                       | false       | Display image Fnumber, Shutter speed, focal length, ISO from METADATA (if available).      |
 | show_image_location               | KIOSK_SHOW_IMAGE_LOCATION | bool                     | false       | Display the image location from METADATA (if available).                                   |
-| hide_usa                          | KIOSK_HIDE_USA          | bool                       | false       | Hide USA when displaying image location                                                    |
+| hide_countries                    | KIOSK_HIDE_COUNTRIES    | []string                   | []          | List of countries whose name will be hidden                                                |
 | show_image_id                     | KIOSK_SHOW_IMAGE_ID     | bool                       | false       | Display the image Immich ID.                                                               |
 
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -53,7 +53,7 @@ show_image_date: false # true or false
 image_date_format: YYYY-MM-DD
 show_image_exif: false
 show_image_location: false
-hide_usa: false
+hide_countries: false
 show_image_id: false
 
 # options that can NOT be changed via url params

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -53,7 +53,7 @@ show_image_date: false # true or false
 image_date_format: YYYY-MM-DD
 show_image_exif: false
 show_image_location: false
-hide_countries: false
+hide_countries: []
 show_image_id: false
 
 # options that can NOT be changed via url params

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -53,6 +53,7 @@ show_image_date: false # true or false
 image_date_format: YYYY-MM-DD
 show_image_exif: false
 show_image_location: false
+hide_usa: false
 show_image_id: false
 
 # options that can NOT be changed via url params

--- a/config/config.go
+++ b/config/config.go
@@ -156,7 +156,7 @@ type Config struct {
 	ShowImageExif bool `mapstructure:"show_image_exif" query:"show_image_exif" form:"show_image_exif" default:"false"`
 	// ShowImageLocation display image location data
 	ShowImageLocation bool `mapstructure:"show_image_location" query:"show_image_location" form:"show_image_location" default:"false"`
-	// HideUSA hide "United States of America" in location information
+	// HideCountries hide country names in location information
 	HideCountries []string `mapstructure:"hide_countries" query:"hide_countries" form:"hide_countries" default:"[]"`
 	// ShowImageID display image ID
 	ShowImageID bool `mapstructure:"show_image_id" query:"show_image_id" form:"show_image_id" default:"false"`

--- a/config/config.go
+++ b/config/config.go
@@ -156,6 +156,8 @@ type Config struct {
 	ShowImageExif bool `mapstructure:"show_image_exif" query:"show_image_exif" form:"show_image_exif" default:"false"`
 	// ShowImageLocation display image location data
 	ShowImageLocation bool `mapstructure:"show_image_location" query:"show_image_location" form:"show_image_location" default:"false"`
+	// HideUSA hide "United States of America" in location information
+	HideUSA bool `mapstructure:"hide_usa" query:"hide_usa" form:"hide_usa" default:"false"`
 	// ShowImageID display image ID
 	ShowImageID bool `mapstructure:"show_image_id" query:"show_image_id" form:"show_image_id" default:"false"`
 

--- a/config/config.go
+++ b/config/config.go
@@ -157,7 +157,7 @@ type Config struct {
 	// ShowImageLocation display image location data
 	ShowImageLocation bool `mapstructure:"show_image_location" query:"show_image_location" form:"show_image_location" default:"false"`
 	// HideUSA hide "United States of America" in location information
-	HideUSA bool `mapstructure:"hide_usa" query:"hide_usa" form:"hide_usa" default:"false"`
+	HideCountries []string `mapstructure:"hide_countries" query:"hide_countries" form:"hide_countries" default:"[]"`
 	// ShowImageID display image ID
 	ShowImageID bool `mapstructure:"show_image_id" query:"show_image_id" form:"show_image_id" default:"false"`
 

--- a/views/views_image.templ
+++ b/views/views_image.templ
@@ -32,7 +32,7 @@ templ ImageFitContain(ImageData, imageFit string) {
 	/>
 }
 
-func ImageLocation(info immich.ExifInfo) string {
+func ImageLocation(viewData ViewData, info immich.ExifInfo) string {
 	var location strings.Builder
 
 	if info.City != "" {
@@ -44,7 +44,7 @@ func ImageLocation(info immich.ExifInfo) string {
 		location.WriteString(info.State)
 	}
 
-	if info.Country != "" {
+	if info.Country != "" && !(viewData.HideUSA && info.Country == "United States of America") {
 		location.WriteString("<span>, </span><br class=\"responsive-break\"/>")
 		location.WriteString(info.Country)
 	}
@@ -124,7 +124,7 @@ templ imageMetadata(viewData ViewData, imageIndex int) {
 		}
 		if viewData.ShowImageLocation {
 			<div class="image--metadata--location">
-				@templ.Raw(ImageLocation(viewData.Images[imageIndex].ImmichImage.ExifInfo))
+				@templ.Raw(ImageLocation(viewData, viewData.Images[imageIndex].ImmichImage.ExifInfo))
 			</div>
 		}
 		if viewData.ShowImageID {

--- a/views/views_image.templ
+++ b/views/views_image.templ
@@ -7,6 +7,7 @@ import (
 	"github.com/damongolding/immich-kiosk/utils"
 	"strings"
 	"time"
+	"slices"
 )
 
 templ ImageFitCover(ImageData, imageFit string) {
@@ -44,7 +45,7 @@ func ImageLocation(viewData ViewData, info immich.ExifInfo) string {
 		location.WriteString(info.State)
 	}
 
-	if info.Country != "" && !(viewData.HideUSA && info.Country == "United States of America") {
+	if info.Country != "" && !slices.Contains(viewData.HideCountries, info.Country) {
 		location.WriteString("<span>, </span><br class=\"responsive-break\"/>")
 		location.WriteString(info.Country)
 	}

--- a/views/views_image_templ.go
+++ b/views/views_image_templ.go
@@ -143,7 +143,7 @@ func ImageFitContain(ImageData, imageFit string) templ.Component {
 	})
 }
 
-func ImageLocation(info immich.ExifInfo) string {
+func ImageLocation(viewData ViewData, info immich.ExifInfo) string {
 	var location strings.Builder
 
 	if info.City != "" {
@@ -155,7 +155,7 @@ func ImageLocation(info immich.ExifInfo) string {
 		location.WriteString(info.State)
 	}
 
-	if info.Country != "" {
+	if info.Country != "" && !(viewData.HideUSA && info.Country == "United States of America") {
 		location.WriteString("<span>, </span><br class=\"responsive-break\"/>")
 		location.WriteString(info.Country)
 	}
@@ -302,7 +302,7 @@ func imageMetadata(viewData ViewData, imageIndex int) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templ.Raw(ImageLocation(viewData.Images[imageIndex].ImmichImage.ExifInfo)).Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = templ.Raw(ImageLocation(viewData, viewData.Images[imageIndex].ImmichImage.ExifInfo)).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/views/views_image_templ.go
+++ b/views/views_image_templ.go
@@ -13,6 +13,7 @@ import (
 	"github.com/damongolding/immich-kiosk/config"
 	"github.com/damongolding/immich-kiosk/immich"
 	"github.com/damongolding/immich-kiosk/utils"
+	"slices"
 	"strings"
 	"time"
 )
@@ -45,7 +46,7 @@ func ImageFitCover(ImageData, imageFit string) templ.Component {
 		var templ_7745c5c3_Var2 string
 		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(ImageData)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/views_image.templ`, Line: 15, Col: 17}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/views_image.templ`, Line: 16, Col: 17}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 		if templ_7745c5c3_Err != nil {
@@ -87,7 +88,7 @@ func ImageFitNone(ImageData, imageFit string) templ.Component {
 		var templ_7745c5c3_Var4 string
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(ImageData)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/views_image.templ`, Line: 22, Col: 17}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/views_image.templ`, Line: 23, Col: 17}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
@@ -129,7 +130,7 @@ func ImageFitContain(ImageData, imageFit string) templ.Component {
 		var templ_7745c5c3_Var6 string
 		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(ImageData)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/views_image.templ`, Line: 30, Col: 17}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/views_image.templ`, Line: 31, Col: 17}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 		if templ_7745c5c3_Err != nil {
@@ -155,7 +156,7 @@ func ImageLocation(viewData ViewData, info immich.ExifInfo) string {
 		location.WriteString(info.State)
 	}
 
-	if info.Country != "" && !(viewData.HideUSA && info.Country == "United States of America") {
+	if info.Country != "" && !slices.Contains(viewData.HideCountries, info.Country) {
 		location.WriteString("<span>, </span><br class=\"responsive-break\"/>")
 		location.WriteString(info.Country)
 	}
@@ -272,7 +273,7 @@ func imageMetadata(viewData ViewData, imageIndex int) templ.Component {
 			var templ_7745c5c3_Var10 string
 			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(ImageDateTime(viewData, imageIndex))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/views_image.templ`, Line: 117, Col: 41}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/views_image.templ`, Line: 118, Col: 41}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 			if templ_7745c5c3_Err != nil {
@@ -319,7 +320,7 @@ func imageMetadata(viewData ViewData, imageIndex int) templ.Component {
 			var templ_7745c5c3_Var11 string
 			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(viewData.Images[imageIndex].ImmichImage.ID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/views_image.templ`, Line: 132, Col: 48}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/views_image.templ`, Line: 133, Col: 48}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 			if templ_7745c5c3_Err != nil {
@@ -389,7 +390,7 @@ func layoutSingleView(viewData ViewData) templ.Component {
 			var templ_7745c5c3_Var15 string
 			templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(viewData.Images[0].ImageBlurData)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/views_image.templ`, Line: 142, Col: 47}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/views_image.templ`, Line: 143, Col: 47}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 			if templ_7745c5c3_Err != nil {
@@ -540,7 +541,7 @@ func layoutSplitView(viewData ViewData) templ.Component {
 				var templ_7745c5c3_Var23 string
 				templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(imageData.ImageBlurData)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/views_image.templ`, Line: 173, Col: 40}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/views_image.templ`, Line: 174, Col: 40}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 				if templ_7745c5c3_Err != nil {
@@ -664,7 +665,7 @@ func Image(viewData ViewData) templ.Component {
 			var templ_7745c5c3_Var27 string
 			templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(historyEntry)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/views_image.templ`, Line: 206, Col: 88}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/views_image.templ`, Line: 207, Col: 88}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 			if templ_7745c5c3_Err != nil {
@@ -683,7 +684,7 @@ func Image(viewData ViewData) templ.Component {
 			var templ_7745c5c3_Var28 string
 			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(newHistoryEntry.ImmichImage.ID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/views_image.templ`, Line: 209, Col: 106}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/views_image.templ`, Line: 210, Col: 106}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 			if templ_7745c5c3_Err != nil {


### PR DESCRIPTION
I found that a lot of photo location information was taking up a large portion of my screen, eg "New York City, New York, United States of America" is rather verbose. Preferably, this would just say "New York City, New York" as (since I'm from USA) I know what places are/aren't in my country.

This PR adds a simple config "hide_countries" to not show countries for whatever countries you may be familiar with.

Happy to make changes if you have a preferred/different/more general way you'd like an option like this exposed:)