### PR TITLE
fix: use exif to fix image orientation

### DIFF
--- a/internal/routes/routes_image_helpers.go
+++ b/internal/routes/routes_image_helpers.go
@@ -128,7 +128,7 @@ func fetchImagePreview(immichImage *immich.ImmichAsset, requestID, kioskDeviceID
 		log.Debug(requestID, "Got image in", time.Since(imageGet).Seconds())
 	}
 
-	img = utils.FixImageOrientation(img, immichImage.IsLandscape, immichImage.ExifInfo.Orientation)
+	img = utils.ApplyExifOrientation(img, immichImage.IsLandscape, immichImage.ExifInfo.Orientation)
 
 	return img, nil
 }

--- a/internal/routes/routes_image_helpers.go
+++ b/internal/routes/routes_image_helpers.go
@@ -128,6 +128,8 @@ func fetchImagePreview(immichImage *immich.ImmichAsset, requestID, kioskDeviceID
 		log.Debug(requestID, "Got image in", time.Since(imageGet).Seconds())
 	}
 
+	img = utils.FixImageOrientation(img, immichImage.IsLandscape, immichImage.ExifInfo.Orientation)
+
 	return img, nil
 }
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -144,7 +144,7 @@ func BytesToImage(imgBytes []byte) (image.Image, error) {
 	return img, nil
 }
 
-// FixImageOrientation adjusts an image's orientation based on EXIF data and desired landscape/portrait mode.
+// ApplyExifOrientation adjusts an image's orientation based on EXIF data and desired landscape/portrait mode.
 // It takes an image, a boolean indicating if landscape orientation is desired, and an EXIF orientation string.
 // The EXIF orientation values follow the standard specification:
 //
@@ -158,7 +158,7 @@ func BytesToImage(imgBytes []byte) (image.Image, error) {
 //	8 = Rotated 90° CW
 //
 // Returns the properly oriented image.
-func FixImageOrientation(img image.Image, isLandscape bool, exifOrientation string) image.Image {
+func ApplyExifOrientation(img image.Image, isLandscape bool, exifOrientation string) image.Image {
 
 	if img == nil {
 		return nil

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -144,6 +144,20 @@ func BytesToImage(imgBytes []byte) (image.Image, error) {
 	return img, nil
 }
 
+// FixImageOrientation adjusts an image's orientation based on EXIF data and desired landscape/portrait mode.
+// It takes an image, a boolean indicating if landscape orientation is desired, and an EXIF orientation string.
+// The EXIF orientation values follow the standard specification:
+//
+//	1 = Normal
+//	2 = Flipped horizontally
+//	3 = Rotated 180 degrees
+//	4 = Flipped vertically
+//	5 = Transposed (flipped horizontally and rotated 90° CW)
+//	6 = Rotated 90° CCW
+//	7 = Transverse (flipped horizontally and rotated 90° CCW)
+//	8 = Rotated 90° CW
+//
+// Returns the properly oriented image.
 func FixImageOrientation(img image.Image, isLandscape bool, exifOrientation string) image.Image {
 
 	// return if image is already in the correct orientation

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -144,6 +144,33 @@ func BytesToImage(imgBytes []byte) (image.Image, error) {
 	return img, nil
 }
 
+func FixImageOrientation(img image.Image, isLandscape bool, exifOrientation string) image.Image {
+
+	// return if image is already in the correct orientation
+	if (img.Bounds().Dy() > img.Bounds().Dx() && !isLandscape) || (img.Bounds().Dx() > img.Bounds().Dy() && isLandscape) {
+		return img
+	}
+
+	switch exifOrientation {
+	case "2":
+		return imaging.FlipH(img)
+	case "3":
+		return imaging.Rotate180(img)
+	case "4":
+		return imaging.FlipV(img)
+	case "5":
+		return imaging.Transpose(img)
+	case "6":
+		return imaging.Rotate270(img)
+	case "7":
+		return imaging.Transverse(img)
+	case "8":
+		return imaging.Rotate90(img)
+	default:
+		return img
+	}
+}
+
 // ImageToBase64 converts an image.Image to a base64 encoded data URI string with appropriate MIME type
 func ImageToBase64(img image.Image) (string, error) {
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -160,8 +160,21 @@ func BytesToImage(imgBytes []byte) (image.Image, error) {
 // Returns the properly oriented image.
 func FixImageOrientation(img image.Image, isLandscape bool, exifOrientation string) image.Image {
 
+	if img == nil {
+		return nil
+	}
+
+	bounds := img.Bounds()
+	width := bounds.Dx()
+	height := bounds.Dy()
+
+	if width == height {
+		return img
+	}
+
 	// return if image is already in the correct orientation
-	if (img.Bounds().Dy() > img.Bounds().Dx() && !isLandscape) || (img.Bounds().Dx() > img.Bounds().Dy() && isLandscape) {
+	isCurrentlyLandscape := width > height
+	if isCurrentlyLandscape == isLandscape {
 		return img
 	}
 


### PR DESCRIPTION
when enabling `use_original_image` in the configuration, immich returns an image with the wrong height/width. the data about the orientation is in the EXIF.

after converting the asset to `img`, there is a need to rotate/flip the image according to the EXIF.

if the `use_original_image` is `false`, it returns in the right orientation + the orientation in the EXIF. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new utility for correcting image orientation based on EXIF data.
- **Bug Fixes**
	- Enhanced image retrieval by ensuring correct orientation is applied before returning images.
	- Improved error handling for image decoding with additional logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->