### PR TITLE
fix mime type when using the raw image endpoint

### DIFF
--- a/internal/routes/routes_image.go
+++ b/internal/routes/routes_image.go
@@ -97,6 +97,6 @@ func NewRawImage(baseConfig *config.Config) echo.HandlerFunc {
 			return err
 		}
 
-		return c.Blob(http.StatusOK, immichImage.OriginalMimeType, imgBytes)
+		return c.Blob(http.StatusOK, "image/jpeg", imgBytes)
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the MIME type for raw image responses to a static value of "image/jpeg", which may affect clients relying on the original MIME type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->