### PR TITLE
feature: support multiple users with multiple api keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ services:
       KIOSK_PREFETCH: true
       KIOSK_ASSET_WEIGHTING: true
       KIOSK_PORT: 3000
+      KIOSK_SHOW_USER: false
     ports:
       - 3000:3000
     restart: always
@@ -386,6 +387,8 @@ See the file `config.example.yaml` for an example config file
 | show_more_info                    | KIOSK_SHOW_MORE_INFO            | bool               | true        | Enables the display of additional information about the current image(s) |
 | show_more_info_image_link         | KIOSK_SHOW_MORE_INFO_IMAGE_LINK | bool               | true        | Shows a link to the original image (in Immich) in the additional information overlay |
 | show_more_info_qr_code            | KIOSK_SHOW_MORE_INFO_QR_CODE    | bool               | true        | Displays a QR code linking to the original image (in Immich) in the additional information overlay |
+| immich_users_api_keys                       | N/A                | map[string]string          | "{}"        | The API key for each user for your Immich server. See [multiple users](#multiple-users) for more information |
+| show_user                             | KIOSK_SHOW_USER                      | bool                       | false       | Display the User used to fetch the image. See [multiple users](#multiple-users) for more information|
 | [weather](#weather)               | N/A                     | []WeatherLocation          | []          | Display the current weather. See [weather](#weather) for more information.                 |
 
 ### Additional options
@@ -397,6 +400,8 @@ immich_api_key: "****"
 // all your other config options
 
 // 👇 Additional options
+immich_users_api_keys:
+  john: "****"
 kiosk:
   password: ""
   cache: true
@@ -429,6 +434,20 @@ Example:
 The above would set refresh to 120 seconds (2 minutes), turn off the background blurred image and remove all transitions for this device/browser.
 
 ------
+
+## Multiple Users
+If you want to use Immich Kiosk with multiple users, you can!
+You'll need to create an api key for each user, and add them to the `immich_users_api_keys` field in the `config.yaml` file:
+```yaml
+immich_users_api_keys:
+  john: "****"
+  jane: "****"
+```
+
+Then you can specify which user to use in the URL:
+`https://{URL}?user=john`
+
+When no user is specified, Kiosk will use the default api key (`immich_api_key`)
 
 ## Albums
 

--- a/README.md
+++ b/README.md
@@ -371,11 +371,11 @@ See the file `config.example.yaml` for an example config file
 | cross_fade_transition_duration    | KIOSK_CROSS_FADE_TRANSITION_DURATION | float         | 1           | The duration of the cross-fade (in seconds) transition.                                    |
 | show_progress                     | KIOSK_SHOW_PROGRESS     | bool                       | false       | Display a progress bar for when image will refresh.                                        |
 | [image_fit](#image-fit)           | KIOSK_IMAGE_FIT         | cover \| contain \| none   | contain     | How your image will fit on the screen. Default is contain. See [Image fit](#image-fit) for more info. |
-| [image_effect](#image-effects)        | KIOSK_IMAGE_EFFECT        | zoom \| smart-zoom    | ""          | Add an effect to images.                                                               |
-| [image_effect_amount](#image-effects) | KIOSK_IMAGE_EFFECT_AMOUNT | int                   | 120         | Set the intensity of the image effect. Use a number between 100 (minimum) and higher, without the % symbol. |
+| [image_effect](#image-effects)        | KIOSK_IMAGE_EFFECT        | zoom \| smart-zoom   | ""          | Add an effect to images.                                                                   |
+| [image_effect_amount](#image-effects) | KIOSK_IMAGE_EFFECT_AMOUNT | int                  | 120         | Set the intensity of the image effect. Use a number between 100 (minimum) and higher, without the % symbol. |
 | use_original_image                | KIOSK_USE_ORIGINAL_IMAGE | bool                      | false       | Use the original image. NOTE: If the original is not a png, gif, jpeg or webp Kiosk will fallback to using the preview. |
-| show_album_name                   | KIOSK_SHOW_ALBUM_NAME   | bool                       | false       | Display the album name if one or more album IDs are specified.                          |
-| show_person_name                  | KIOSK_SHOW_PERSON_NAME  | bool                       | false       | Display the person name if one or more person IDs are specified.                        |
+| show_album_name                   | KIOSK_SHOW_ALBUM_NAME   | bool                       | false       | Display the album name if one or more album IDs are specified.                             |
+| show_person_name                  | KIOSK_SHOW_PERSON_NAME  | bool                       | false       | Display the person name if one or more person IDs are specified.                           |
 | show_image_time                   | KIOSK_SHOW_IMAGE_TIME   | bool                       | false       | Display image time from METADATA (if available).                                           |
 | image_time_format                 | KIOSK_IMAGE_TIME_FORMAT | 12 \| 24                   | 24          | Display image time in either 12 hour or 24 hour format. Can either be 12 or 24.            |
 | show_image_date                   | KIOSK_SHOW_IMAGE_DATE   | bool                       | false       | Display the image date from METADATA (if available).                                       |
@@ -383,12 +383,12 @@ See the file `config.example.yaml` for an example config file
 | show_image_description            | KIOSK_SHOW_IMAGE_DESCRIPTION | bool                  | false       | Display image description from METADATA (if available). |
 | show_image_exif                   | KIOSK_SHOW_IMAGE_EXIF   | bool                       | false       | Display image Fnumber, Shutter speed, focal length, ISO from METADATA (if available).      |
 | show_image_location               | KIOSK_SHOW_IMAGE_LOCATION | bool                     | false       | Display the image location from METADATA (if available).                                   |
-| hide_countries                    | KIOSK_HIDE_COUNTRIES    | []string                   | []          | List of countries to hide from image_location                                                |
-| show_more_info                    | KIOSK_SHOW_MORE_INFO            | bool               | true        | Enables the display of additional information about the current image(s) |
-| show_more_info_image_link         | KIOSK_SHOW_MORE_INFO_IMAGE_LINK | bool               | true        | Shows a link to the original image (in Immich) in the additional information overlay |
+| hide_countries                    | KIOSK_HIDE_COUNTRIES    | []string                   | []          | List of countries to hide from image_location                                              |
+| show_more_info                    | KIOSK_SHOW_MORE_INFO            | bool               | true        | Enables the display of additional information about the current image(s)                   |
+| show_more_info_image_link         | KIOSK_SHOW_MORE_INFO_IMAGE_LINK | bool               | true        | Shows a link to the original image (in Immich) in the additional information overlay       |
 | show_more_info_qr_code            | KIOSK_SHOW_MORE_INFO_QR_CODE    | bool               | true        | Displays a QR code linking to the original image (in Immich) in the additional information overlay |
-| immich_users_api_keys                       | N/A                | map[string]string          | "{}"        | The API key for each user for your Immich server. See [multiple users](#multiple-users) for more information |
-| show_user                             | KIOSK_SHOW_USER                      | bool                       | false       | Display the User used to fetch the image. See [multiple users](#multiple-users) for more information|
+| immich_users_api_keys             | N/A                     | map[string]string          | {}          | key:value mappings of Immich usernames to their corresponding API keys. See [multiple users](#multiple-users) for more information |
+| show_user                         | KIOSK_SHOW_USER         | bool                       | false       | Display the user used to fetch the image. See [multiple users](#multiple-users) for more information |
 | [weather](#weather)               | N/A                     | []WeatherLocation          | []          | Display the current weather. See [weather](#weather) for more information.                 |
 
 ### Additional options
@@ -400,8 +400,6 @@ immich_api_key: "****"
 // all your other config options
 
 // 👇 Additional options
-immich_users_api_keys:
-  john: "****"
 kiosk:
   password: ""
   cache: true
@@ -436,18 +434,33 @@ The above would set refresh to 120 seconds (2 minutes), turn off the background 
 ------
 
 ## Multiple Users
-If you want to use Immich Kiosk with multiple users, you can!
-You'll need to create an api key for each user, and add them to the `immich_users_api_keys` field in the `config.yaml` file:
+
+> [!TIP]
+> You can remove specific asset sources that were previously set in your `config.yaml` or environment variables. To do this, use `none` in the URL query parameters.
+>
+> Example:
+> ```url
+> https://{URL}?user=USER&person=none&album=none
+> ```
+>
+> This will disable both the 'person' and 'album' asset sources.
+
+Immich Kiosk supports multiple user API keys. Here's how to set it up:
+
+1. Configure multiple users by adding their API keys to the `immich_users_api_keys` field in your `config.yaml`:
 ```yaml
 immich_users_api_keys:
-  john: "****"
-  jane: "****"
+  john: "api_key_here"
+  jane: "api_key_here"
 ```
 
-Then you can specify which user to use in the URL:
-`https://{URL}?user=john`
+2. Access a specific user's content by including the `user` parameter in the URL:
+```
+https://{URL}?user=john
+```
 
-When no user is specified, Kiosk will use the default api key (`immich_api_key`)
+> [!NOTE]
+> If no user is specified in the URL, Immich Kiosk will default to using the global API key defined in `immich_api_key`.
 
 ## Albums
 

--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ The above would set refresh to 120 seconds (2 minutes), turn off the background 
 ## Multiple Users
 
 > [!TIP]
-> You can remove specific asset sources that were previously set in your `config.yaml` or environment variables. To do this, use `none` in the URL query parameters.
+> You can remove specific asset sources that were previously set in your `config.yaml` or environment variables by using `none` in the URL query parameters.
 >
 > Example:
 > ```url

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -79,11 +79,6 @@ show_more_info: true
 show_more_info_image_link: true
 show_more_info_qr_code: true
 
-# Advanced - Immich API keys for specific users
-immich_users_api_keys:
-  user1: ""
-show_user: true # show user name
-
 ## Weather feature - you’ll need an API key from OpenWeatherMap
 # weather:
 #   - name: london
@@ -92,6 +87,11 @@ show_user: true # show user name
 #     api: ""
 #     unit: metric
 #     lang: en
+
+## Immich API keys for specific users
+# immich_users_api_keys:
+#   user1: ""
+# show_user: false # show user name
 
 ## Options that can NOT be changed via url params
 kiosk:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -79,6 +79,11 @@ show_more_info: true
 show_more_info_image_link: true
 show_more_info_qr_code: true
 
+# Advanced - Immich API keys for specific users
+immich_users_api_keys:
+  user1: ""
+show_user: true # show user name
+
 ## Weather feature - you’ll need an API key from OpenWeatherMap
 # weather:
 #   - name: london

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -46,8 +46,8 @@ func ViewCacheKey(apiUrl, deviceID string) string {
 // ApiCacheKey generates a cache key from the API URL and device ID by combining them
 // with ':api' suffix for cache API operations. The key is hashed using SHA-256
 // for consistent length and character set.
-func ApiCacheKey(apiUrl, deviceID string) string {
-	key := fmt.Sprintf("%s:%s:api", apiUrl, deviceID)
+func ApiCacheKey(apiUrl, deviceID string, user string) string {
+	key := fmt.Sprintf("%s:%s:%s:api", apiUrl, deviceID, user)
 	return fmt.Sprintf("%x", sha256.Sum256([]byte(key)))
 }
 

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -97,6 +97,7 @@ type ViewImageData struct {
 	ImageData     string             // ImageData contains the image as base64 data
 	ImageBlurData string             // ImageBlurData contains the blurred image as base64 data
 	ImageDate     string             // ImageDate contains the date of the image
+	User          string
 }
 
 // ViewData contains all the data needed to render a view in the application

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -167,6 +167,7 @@ type Config struct {
 	ShowUser bool `json:"showUser" mapstructure:"show_user" query:"show_user" form:"show_user" default:"false"`
 	// SelectedUser selected user from User for the specific request
 	SelectedUser string `json:"selectedUser" default:""`
+
 	// DisableUi a shortcut to disable ShowTime, ShowDate, ShowImageTime and ShowImageDate
 	DisableUi bool `json:"disableUi" mapstructure:"disable_ui" query:"disable_ui" form:"disable_ui" default:"false"`
 	// Frameless remove border on frames

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -159,6 +159,14 @@ type Config struct {
 	// (e.g., when using reverse proxies or different network paths)
 	ImmichExternalUrl string `json:"-" mapstructure:"immich_external_url" default:""`
 
+	// ImmichUsersApiKeys a map of usernames to their respective api keys for accessing Immich
+	ImmichUsersApiKeys map[string]string `json:"-" mapstructure:"immich_users_api_keys" default:"{}"`
+	// User the user from ImmichUsersApiKeys to use when fetching images. If not set, it will use the default ImmichApiKey
+	User []string `json:"user" mapstructure:"user" query:"user" form:"user" default:"[]"`
+	// ShowUser whether to display user
+	ShowUser bool `json:"showUser" mapstructure:"show_user" query:"show_user" form:"show_user" default:"false"`
+	// SelectedUser selected user from User for the specific request
+	SelectedUser string `json:"selectedUser" default:""`
 	// DisableUi a shortcut to disable ShowTime, ShowDate, ShowImageTime and ShowImageDate
 	DisableUi bool `json:"disableUi" mapstructure:"disable_ui" query:"disable_ui" form:"disable_ui" default:"false"`
 	// Frameless remove border on frames

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -20,10 +20,12 @@ func TestImmichUrlImmichApiKeyImmutability(t *testing.T) {
 
 	originalUrl := "https://my-server.com"
 	originalApi := "123456"
+	originalUsersApiKeys := map[string]string{"default": "123456"}
 
 	c := New()
 	c.ImmichUrl = originalUrl
 	c.ImmichApiKey = originalApi
+	c.ImmichUsersApiKeys = originalUsersApiKeys
 
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -31,6 +33,7 @@ func TestImmichUrlImmichApiKeyImmutability(t *testing.T) {
 	q := req.URL.Query()
 	q.Add("immich_url", "https://my-new-server.com")
 	q.Add("immich_api_key", "9999")
+	q.Add("immich_users_api_keys", "{\"user1\": \"9999\"}")
 
 	req.URL.RawQuery = q.Encode()
 
@@ -43,6 +46,7 @@ func TestImmichUrlImmichApiKeyImmutability(t *testing.T) {
 
 	assert.Equal(t, originalUrl, c.ImmichUrl, "ImmichUrl field was allowed to be changed")
 	assert.Equal(t, originalApi, c.ImmichApiKey, "ImmichApiKey field was allowed to be changed")
+	assert.Equal(t, originalUsersApiKeys, c.ImmichUsersApiKeys, "ImmichUsersApiKeys field was allowed to be changed")
 }
 
 // TestImmichUrlImmichMulitplePerson tests the addition of multiple persons to the config

--- a/internal/immich/immich.go
+++ b/internal/immich/immich.go
@@ -6,6 +6,7 @@
 package immich
 
 import (
+	"fmt"
 	"net"
 	"net/http"
 	"time"
@@ -234,4 +235,8 @@ type ImmichApiCall func(string, string, []byte) ([]byte, error)
 
 type ImmichApiResponse interface {
 	ImmichAsset | []ImmichAsset | ImmichAlbum | ImmichAlbums | ImmichPersonStatistics | int | ImmichSearchMetadataResponse | []Face | immich_open_api.PersonResponseDto | MemoryLaneResponse
+}
+
+func ApiCacheKey(apiUrl string, requestConfig *config.Config) string {
+	return fmt.Sprintf("%s:%s", apiUrl, requestConfig.SelectedUser)
 }

--- a/internal/immich/immich.go
+++ b/internal/immich/immich.go
@@ -6,7 +6,6 @@
 package immich
 
 import (
-	"fmt"
 	"net"
 	"net/http"
 	"time"
@@ -235,8 +234,4 @@ type ImmichApiCall func(string, string, []byte) ([]byte, error)
 
 type ImmichApiResponse interface {
 	ImmichAsset | []ImmichAsset | ImmichAlbum | ImmichAlbums | ImmichPersonStatistics | int | ImmichSearchMetadataResponse | []Face | immich_open_api.PersonResponseDto | MemoryLaneResponse
-}
-
-func ApiCacheKey(apiUrl string, requestConfig *config.Config) string {
-	return fmt.Sprintf("%s:%s", apiUrl, requestConfig.SelectedUser)
 }

--- a/internal/immich/immich_album.go
+++ b/internal/immich/immich_album.go
@@ -174,7 +174,7 @@ func (i *ImmichAsset) ImageFromAlbum(albumID string, albumAssetsOrder ImmichAsse
 			return err
 		}
 
-		apiCacheKey := cache.ApiCacheKey(apiUrl, deviceID)
+		apiCacheKey := cache.ApiCacheKey(apiUrl, deviceID, requestConfig.SelectedUser)
 
 		if len(album.Assets) == 0 {
 			log.Debug(requestID+" No images left in cache. Refreshing and trying again for album", albumID)

--- a/internal/immich/immich_date.go
+++ b/internal/immich/immich_date.go
@@ -122,7 +122,7 @@ func (i *ImmichAsset) RandomImageInDateRange(dateRange, requestID, deviceID stri
 			return err
 		}
 
-		apiCacheKey := cache.ApiCacheKey(apiUrl.String(), deviceID)
+		apiCacheKey := cache.ApiCacheKey(apiUrl.String(), deviceID, requestConfig.SelectedUser)
 
 		if len(immichAssets) == 0 {
 			log.Debug(requestID + " No images left in cache. Refreshing and trying again")

--- a/internal/immich/immich_favourites.go
+++ b/internal/immich/immich_favourites.go
@@ -165,7 +165,7 @@ func (i *ImmichAsset) RandomImageFromFavourites(requestID, deviceID string, isPr
 			return err
 		}
 
-		apiCacheKey := cache.ApiCacheKey(apiUrl.String(), deviceID)
+		apiCacheKey := cache.ApiCacheKey(apiUrl.String(), deviceID, requestConfig.SelectedUser)
 
 		if len(immichAssets) == 0 {
 			log.Debug(requestID + " No images left in cache. Refreshing and trying again")

--- a/internal/immich/immich_helpers.go
+++ b/internal/immich/immich_helpers.go
@@ -107,8 +107,9 @@ func (i *ImmichAsset) immichApiCall(method, apiUrl string, body []byte) ([]byte,
 		req.Header.Set("Accept", "application/json")
 		apiKey := requestConfig.ImmichApiKey
 		if requestConfig.SelectedUser != "" {
-			apiKey = requestConfig.ImmichUsersApiKeys[requestConfig.SelectedUser]
-			if apiKey == "" {
+			if key, ok := requestConfig.ImmichUsersApiKeys[requestConfig.SelectedUser]; ok {
+				apiKey = key
+			} else {
 				return responseBody, fmt.Errorf("no API key found for user %s in the config", requestConfig.SelectedUser)
 			}
 		}

--- a/internal/immich/immich_helpers.go
+++ b/internal/immich/immich_helpers.go
@@ -36,7 +36,7 @@ func immichApiCallDecorator[T ImmichApiResponse](immichApiCall ImmichApiCall, re
 			return immichApiCall(method, apiUrl, body)
 		}
 
-		apiCacheKey := cache.ApiCacheKey(apiUrl, deviceID)
+		apiCacheKey := cache.ApiCacheKey(apiUrl, deviceID, requestConfig.SelectedUser)
 
 		if apiData, found := cache.Get(apiCacheKey); found {
 			if requestConfig.Kiosk.DebugVerbose {
@@ -105,7 +105,12 @@ func (i *ImmichAsset) immichApiCall(method, apiUrl string, body []byte) ([]byte,
 		}
 
 		req.Header.Set("Accept", "application/json")
-		req.Header.Set("x-api-key", requestConfig.ImmichApiKey)
+		apiKey := requestConfig.ImmichApiKey
+		if requestConfig.SelectedUser != "" {
+			apiKey = requestConfig.ImmichUsersApiKeys[requestConfig.SelectedUser]
+		}
+
+		req.Header.Set("x-api-key", apiKey)
 
 		if method == "POST" || method == "PUT" || method == "PATCH" {
 			req.Header.Set("Content-Type", "application/json")

--- a/internal/immich/immich_memories.go
+++ b/internal/immich/immich_memories.go
@@ -88,7 +88,7 @@ func (i *ImmichAsset) RandomMemoryLaneImage(requestID, deviceID string, isPrefet
 			return err
 		}
 
-		apiCacheKey := cache.ApiCacheKey(apiUrl, deviceID)
+		apiCacheKey := cache.ApiCacheKey(apiUrl, deviceID, requestConfig.SelectedUser)
 
 		if len(memories) == 0 {
 			log.Debug(requestID + " No images left in cache. Refreshing and trying again for memories")

--- a/internal/immich/immich_person.go
+++ b/internal/immich/immich_person.go
@@ -115,7 +115,7 @@ func (i *ImmichAsset) RandomImageOfPerson(personID, requestID, deviceID string, 
 			return err
 		}
 
-		apiCacheKey := cache.ApiCacheKey(apiUrl.String(), deviceID)
+		apiCacheKey := cache.ApiCacheKey(apiUrl.String(), deviceID, requestConfig.SelectedUser)
 
 		if len(immichAssets) == 0 {
 			log.Debug(requestID + " No images left in cache. Refreshing and trying again")

--- a/internal/immich/immich_random.go
+++ b/internal/immich/immich_random.go
@@ -85,7 +85,7 @@ func (i *ImmichAsset) RandomImage(requestID, deviceID string, isPrefetch bool) e
 			return err
 		}
 
-		apiCacheKey := cache.ApiCacheKey(apiUrl.String(), deviceID)
+		apiCacheKey := cache.ApiCacheKey(apiUrl.String(), deviceID, requestConfig.SelectedUser)
 
 		if len(immichAssets) == 0 {
 			log.Debug(requestID + " No images left in cache. Refreshing and trying again")

--- a/internal/routes/routes_image_helpers.go
+++ b/internal/routes/routes_image_helpers.go
@@ -40,11 +40,14 @@ func gatherAssetBuckets(immichImage *immich.ImmichAsset, requestConfig config.Co
 	assets := []utils.AssetWithWeighting{}
 
 	for _, person := range requestConfig.Person {
+		if person == "" || strings.EqualFold(person, "none") {
+			continue
+		}
+
 		personAssetCount, err := immichImage.PersonImageCount(person, requestID, deviceID)
 		if err != nil {
 			if requestConfig.SelectedUser != "" {
-				log.Debug(requestID+" User has no Person", "user", requestConfig.SelectedUser, "person", person)
-				continue
+				return nil, fmt.Errorf("user '<b>%s</b>' has no Person '%s'. error='%w'", requestConfig.SelectedUser, person, err)
 			}
 			return nil, fmt.Errorf("getting person image count: %w", err)
 		}
@@ -61,12 +64,14 @@ func gatherAssetBuckets(immichImage *immich.ImmichAsset, requestConfig config.Co
 	}
 
 	for _, album := range requestConfig.Album {
+		if album == "" || strings.EqualFold(album, "none") {
+			continue
+		}
 
 		albumAssetCount, err := immichImage.AlbumImageCount(album, requestID, deviceID)
 		if err != nil {
 			if requestConfig.SelectedUser != "" {
-				log.Debug(requestID+" User has no album", "user", requestConfig.SelectedUser, "album", album)
-				continue
+				return nil, fmt.Errorf("user '<b>%s</b>' has no Album '%s'. error='%w'", requestConfig.SelectedUser, album, err)
 			}
 			return nil, fmt.Errorf("getting album asset count: %w", err)
 		}
@@ -82,11 +87,10 @@ func gatherAssetBuckets(immichImage *immich.ImmichAsset, requestConfig config.Co
 		})
 	}
 
-	if len(assets) == 0 && (len(requestConfig.Person) > 0 || len(requestConfig.Album) > 0) {
-		return nil, fmt.Errorf("no assets found for user %s with the wanted person or album", requestConfig.SelectedUser)
-	}
-
 	for _, date := range requestConfig.Date {
+		if date == "" || strings.EqualFold(date, "none") {
+			continue
+		}
 
 		// use FetchedAssetsSize as a weighting for date ranges
 		assets = append(assets, utils.AssetWithWeighting{

--- a/internal/routes/routes_image_helpers.go
+++ b/internal/routes/routes_image_helpers.go
@@ -317,6 +317,7 @@ func processViewImageData(imageOrientation immich.ImageOrientation, requestConfi
 	requestID := utils.ColorizeRequestId(c.Response().Header().Get(echo.HeaderXRequestID))
 	deviceID := c.Request().Header.Get("kiosk-device-id")
 
+	// if multiple users are given via the url pick a random one
 	if len(requestConfig.User) > 0 {
 		randomIndex := rand.IntN(len(requestConfig.User))
 		requestConfig.SelectedUser = requestConfig.User[randomIndex]

--- a/internal/routes/routes_previous_image.go
+++ b/internal/routes/routes_previous_image.go
@@ -64,9 +64,15 @@ func PreviousImage(baseConfig *config.Config) echo.HandlerFunc {
 
 		g, _ := errgroup.WithContext(c.Request().Context())
 
-		for i, imageID := range prevImages {
-			i, imageID := i, imageID
+		for i, imageData := range prevImages {
+			i, imageID := i, imageData
+			parts := strings.Split(imageData, ":")
+			if len(parts) != 2 {
+				return fmt.Errorf("invalid history entry format: %s", imageData)
+			}
+			imageID, selectedUser := parts[0], parts[1]
 			g.Go(func() error {
+				requestConfig.SelectedUser = selectedUser
 				image := immich.NewImage(requestConfig)
 				image.ID = imageID
 
@@ -109,6 +115,7 @@ func PreviousImage(baseConfig *config.Config) echo.HandlerFunc {
 					ImmichImage:   image,
 					ImageData:     imgString,
 					ImageBlurData: imgBlurString,
+					User:          selectedUser,
 				}
 				return nil
 			})

--- a/internal/templates/components/image/history.templ
+++ b/internal/templates/components/image/history.templ
@@ -13,7 +13,7 @@ func newHistoryEntry(images []common.ViewImageData) string {
 	newImages := make([]string, len(images))
 	for i, entry := range images {
 		sanitisedID := template.HTMLEscapeString(entry.ImmichImage.ID)
-		newImages[i] = sanitisedID
+		newImages[i] = sanitisedID + ":" + entry.User
 	}
 	return strings.Join(newImages, ",")
 }

--- a/internal/templates/components/image/metadata.templ
+++ b/internal/templates/components/image/metadata.templ
@@ -12,6 +12,8 @@ import (
 	"github.com/damongolding/immich-kiosk/internal/kiosk"
 	"github.com/damongolding/immich-kiosk/internal/utils"
 	"github.com/goodsign/monday"
+	"golang.org/x/text/cases"
+    "golang.org/x/text/language"
 )
 
 // ImageLocation generates a formatted string of the image location based on EXIF information.
@@ -137,7 +139,13 @@ templ imageMetadata(viewData common.ViewData, imageIndex int) {
 	{{ showSourceName := shouldShowSourceName(viewData, imageIndex) }}
 	{{ showDateTime := viewData.ShowImageDate || viewData.ShowImageTime }}
 	{{ showDescription := viewData.ShowImageDescription && viewData.Images[imageIndex].ImmichImage.ExifInfo.Description != "" }}
+	{{ showUser := viewData.ShowUser }}
 	<div class={ "image--metadata", fmt.Sprintf("image--metadata--theme-%s", viewData.Theme) }>
+		if showUser {
+			<div class="image--metadata--source">
+				{ cases.Title(language.English).String(viewData.Images[imageIndex].User) }
+			</div>
+		}
 		if showSourceName {
 			<div class="image--metadata--source">
 				{ viewData.Images[imageIndex].ImmichImage.KioskSourceName }


### PR DESCRIPTION
wanted to use multiple users and saw #https://github.com/damongolding/immich-kiosk/discussions/115#discussioncomment-10895853.
didn't want to break anything so I didn't touch `immich_api_key`, but created `immich_api_keys`.
changed the code to support either `immich_api_keys` or `immich_api_key`, and changed the docs to only use `immich_api_keys`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced multi-user support for the Immich Kiosk, allowing individual API keys per user.
  - Enabled user-specific image information display when configured via the new settings.

- **Documentation**
  - Added a "Multiple Users" section with clear instructions on configuring multi-user API keys.
  - Updated configuration examples and Docker Compose documentation with new environment options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->