### PR TITLE
bypass sleep mode via URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ See the file `config.example.yaml` for an example config file
 | [layout](#layouts)                | KIOSK_LAYOUT            | [Layouts](#layouts)        | single      | Which layout to use. See [Layouts](#layouts) for more information.                         |
 | [sleep_start](#sleep-mode)        | KIOSK_SLEEP_START       | string                     | ""          | Time (in 24hr format) to start sleep mode. See [Sleep mode](#sleep-mode) for more information. |
 | [sleep_end](#sleep-mode)          | KIOSK_SLEEP_END         | string                     | ""          | Time (in 24hr format) to end sleep mode. See [Sleep mode](#sleep-mode) for more information. |
+| [disable_sleep](#sleep-mode)      | N/A                     | bool                       | false       | Bypass sleep mode by adding `disable_sleep=true` to the URL. See [Sleep mode](#sleep-mode) for more information. |
 | [custom_css](#custom-css)         | N/A                     | bool                       | true        | Allow custom CSS to be used. See [Custom CSS](#custom-css) for more information.           |
 | transition                        | KIOSK_TRANSITION        | none \| fade \| cross-fade | none        | Which transition to use when changing images.                                              |
 | fade_transition_duration          | KIOSK_FADE_TRANSITION_DURATION | float               | 1           | The duration of the fade (in seconds) transition.                                          |
@@ -753,6 +754,9 @@ When a landscape image is fetched, Kiosk automatically retrieves a second landsc
 ------
 
 ## Sleep mode
+
+> [!TIP]
+> You can add `disable_sleep=true` to your URL quires to bypass sleepmode.
 
 ### Enabling Sleep Mode:
 Setting both `sleep_start` and `sleep_end` using the 24 hour format will enable sleep mode.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -192,6 +192,8 @@ type Config struct {
 	SleepEnd string `json:"sleepEnd" mapstructure:"sleep_end" query:"sleep_end" form:"sleep_end" default:""`
 	// SleepIcon display sleep icon
 	SleepIcon bool `json:"sleepIcon" mapstructure:"sleep_icon" query:"sleep_icon" form:"sleep_icon" default:"true"`
+	// SleepDisable disable sleep via url queries
+	DisableSleep bool `json:"disableSleep" query:"disable_sleep" form:"disable_sleep" default:"false"`
 
 	// ShowArchived allow archived image to be displayed
 	ShowArchived bool `json:"showArchived" mapstructure:"show_archived" query:"show_archived" form:"show_archived" default:"false"`

--- a/internal/routes/routes_image.go
+++ b/internal/routes/routes_image.go
@@ -40,7 +40,7 @@ func NewImage(baseConfig *config.Config) echo.HandlerFunc {
 			"requestConfig", requestConfig.String(),
 		)
 
-		if isSleepMode(requestConfig) {
+		if !requestConfig.DisableSleep && isSleepMode(requestConfig) {
 			return c.NoContent(http.StatusNoContent)
 		}
 

--- a/internal/routes/routes_previous_image.go
+++ b/internal/routes/routes_previous_image.go
@@ -46,7 +46,7 @@ func PreviousImage(baseConfig *config.Config) echo.HandlerFunc {
 		)
 		historyLen := len(requestConfig.History)
 
-		if isSleepMode(requestConfig) || historyLen < 2 {
+		if (!requestConfig.DisableSleep && isSleepMode(requestConfig)) || historyLen < 2 {
 			return c.NoContent(http.StatusNoContent)
 		}
 

--- a/internal/templates/partials/sleep.templ
+++ b/internal/templates/partials/sleep.templ
@@ -20,8 +20,8 @@ templ SleepController(sleepMode bool, sleepIcon bool) {
 }
 
 // Sleep renders a form for sleep mode functionality
-templ Sleep(sleepStart, sleepEnd string) {
-	if sleepStart != "" && sleepEnd != "" {
+templ Sleep(sleepStart, sleepEnd string, disableSleep bool) {
+	if sleepStart != "" && sleepEnd != "" && !disableSleep {
 		<form
 			hx-get="/sleep"
 			hx-trigger="load, every 15s"

--- a/internal/templates/views/views_home.templ
+++ b/internal/templates/views/views_home.templ
@@ -53,7 +53,7 @@ templ Home(viewData common.ViewData) {
 			}
 			@partials.Menu(viewData.ShowMoreInfo)
 			@partials.Params(viewData.Queries)
-			@partials.Sleep(viewData.SleepStart, viewData.SleepEnd)
+			@partials.Sleep(viewData.SleepStart, viewData.SleepEnd, viewData.DisableSleep)
 			@partials.History()
 			@partials.RefreshCheck(viewData.KioskVersion, viewData.ReloadTimeStamp, viewData.Queries)
 			@partials.OfflineIcon()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added option to bypass sleep mode by appending `disable_sleep=true` to URL queries
  - Provides users with more control over kiosk display behaviour

- **Documentation**
  - Updated README with new sleep mode configuration instructions
  - Corrected spelling of "transition" in example URL

- **Bug Fixes**
  - Fixed minor typographical error in documentation

These changes enhance the kiosk's flexibility, allowing continuous display without sleep mode interruptions when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->