### PR TITLE
README hyperlink typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ There are two main ways to install Kiosk: **Docker** or **Binary**.
      wget -O docker-compose.yaml https://raw.githubusercontent.com/damongolding/immich-kiosk/refs/heads/main/docker-compose.yaml
      ```
 
-     Set `Lang` to a `language code` from [this list](/assets/locals.md))
+     Set `Lang` to a `language code` from [this list](/assets/locales.md))
      Set `TZ` to a `TZ identifier` from [this list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)
 
   3. Create the `config.yaml` file.
@@ -192,7 +192,7 @@ There are two main ways to install Kiosk: **Docker** or **Binary**.
 
 > [!NOTE]
 > You can use both a yaml file and environment variables but environment variables will overwrite settings from the yaml file
-> Set `Lang` to a `language code` from [this list](/assets/locals.md))
+> Set `Lang` to a `language code` from [this list](/assets/locales.md))
 > Set `TZ` to a `TZ identifier` from [this list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List)
 
 ### When using a `config.yaml` config file


### PR DESCRIPTION
typo in hyperlink (locals.md -> locales.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected documentation reference for language code list from `/assets/locals.md` to `/assets/locales.md`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->