### PR TITLE
Rename pre_fetch config option to prefetch for consistency

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -120,5 +120,5 @@ kiosk:
   http_timeout: 20
   password: ""
   cache: true # cache select api calls
-  pre_fetch: true # fetch assets in the background
+  prefetch: true # fetch assets in the background
   asset_weighting: true # use weighting when picking assets


### PR DESCRIPTION
Update the `pre_fetch` key in the exemple config to `prefetch` for consistency with the rest of the project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Renamed the configuration key from `pre_fetch` to `prefetch` under the `kiosk` section in the example configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->