### PR TITLE
Feature/caching for about page

### DIFF
--- a/internal/templates/views/views_about.templ
+++ b/internal/templates/views/views_about.templ
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/charmbracelet/log"
+	"github.com/damongolding/immich-kiosk/internal/cache"
 	"github.com/damongolding/immich-kiosk/internal/common"
 	"github.com/damongolding/immich-kiosk/internal/config"
 	"github.com/damongolding/immich-kiosk/internal/immich"
@@ -126,6 +127,15 @@ func getLatestRelease(owner, repo string) (string, string) {
 	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/latest", owner, repo)
 	link := fmt.Sprintf("https://github.com/%s/%s/releases/latest", owner, repo)
 
+	if tagData, found := cache.Get(url); found {
+		log.Debug("Github release cache hit", "url", url)
+		tag, ok := tagData.(GitHubRelease)
+		if ok {
+			return tag.TagName, link
+		}
+		log.Debug("Github release cache data type assertion failed", "url", url)
+	}
+
 	client := &http.Client{
 		Timeout: 10 * time.Second,
 	}
@@ -154,6 +164,8 @@ func getLatestRelease(owner, repo string) (string, string) {
 	}
 
 	link = fmt.Sprintf("https://github.com/%s/%s/releases/tag/%s", owner, repo, release.TagName)
+
+	cache.Set(url, release)
 
 	return release.TagName, link
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved performance for displaying the latest GitHub release information on the About page. Information now loads faster due to caching of release data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->