### PR TITLE
revert people names and ages

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -326,10 +326,10 @@ type Config struct {
 
 	// ShowAlbumName whether to display the album name
 	ShowAlbumName bool `json:"showAlbumName" yaml:"show_album_name" mapstructure:"show_album_name" query:"show_album_name" form:"show_album_name" default:"false"`
-	// ShowNames whether to display the person name
-	ShowNames bool `json:"ShowNames" yaml:"show_names" mapstructure:"show_names" query:"show_names" form:"show_names" default:"false"`
-	// ShowAges whether to display the person age
-	ShowAges bool `json:"ShowAges" yaml:"show_ages" mapstructure:"show_ages" query:"show_ages" form:"show_ages" default:"false"`
+	// ShowPersonName whether to display the person name
+	ShowPersonName bool `json:"showPersonName" yaml:"show_person_name" mapstructure:"show_person_name" query:"show_person_name" form:"show_person_name" default:"false"`
+	// ShowPersonAge whether to display the person age
+	ShowPersonAge bool `json:"showPersonAge" yaml:"show_person_age" mapstructure:"show_person_age" query:"show_person_age" form:"show_person_age" default:"false"`
 	// AgeSwitchToYearsAfter when to switch from months to years
 	AgeSwitchToYearsAfter int `json:"ageSwitchToYearsAfter" yaml:"age_switch_to_years_after" mapstructure:"age_switch_to_years_after" query:"age_switch_to_years_after" form:"age_switch_to_years_after" default:"1"`
 

--- a/internal/templates/partials/metadata.templ
+++ b/internal/templates/partials/metadata.templ
@@ -45,7 +45,7 @@ templ AssetMetadata(viewData common.ViewData, assetIndex int) {
 	{{ showDateTime := viewData.ShowImageDate || viewData.ShowImageTime }}
 	{{ showDescription := viewData.ShowImageDescription && viewData.Assets[assetIndex].ImmichAsset.ExifInfo.Description != "" }}
 	{{ rightAlignIcons := len(viewData.Assets) > 1 && assetIndex == 1 }}
-	{{ names := peopleNames(viewData.Assets[assetIndex].ImmichAsset.People, viewData.ShowNames, viewData.ShowAges, viewData.AgeSwitchToYearsAfter, viewData.Assets[assetIndex].ImmichAsset.LocalDateTime) }}
+	{{ names := peopleNames(viewData.Assets[assetIndex].ImmichAsset.People, viewData.ShowPersonName, viewData.ShowPersonAge, viewData.AgeSwitchToYearsAfter, viewData.Assets[assetIndex].ImmichAsset.LocalDateTime) }}
 	{{ showUser := viewData.ShowUser }}
 	{{ className := "frame-" + utils.GenerateUUID() }}
 	if viewData.Theme == "bubble" {
@@ -61,7 +61,7 @@ templ AssetMetadata(viewData common.ViewData, assetIndex int) {
 		if viewData.Assets[assetIndex].ImmichAsset.MemoryTitle != "" {
 			@memoryIcon(viewData.Assets[assetIndex].ImmichAsset.MemoryTitle)
 		}
-		if (viewData.ShowNames || viewData.ShowAges) && names != "" {
+		if (viewData.ShowPersonName || viewData.ShowPersonAge) && names != "" {
 			@templ.Raw(AssetPeople(names))
 		}
 		if viewData.ShowAlbumName && len(viewData.Assets[assetIndex].ImmichAsset.AppearsIn) != 0 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed display options for person names and ages to improve clarity in configuration and templates.  
* **Style**
  * Updated naming conventions for consistency across user-facing settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->