### PR TITLE
fix edge case for API and URL are ENVS

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -517,12 +517,12 @@ func (c *Config) Load() error {
 		case !isValidYAML(c.V.ConfigFileUsed()):
 			log.Fatal(err)
 		}
-
 	} else {
 		level := strings.ToLower(strings.TrimSpace(c.V.GetString("kiosk.config_validation_level")))
 		if level != kiosk.ConfigValidationWarning && level != kiosk.ConfigValidationError {
 			level = kiosk.ConfigValidationError
 		}
+
 		valid := checkSchema(c.V.AllSettings(), level)
 		if !valid && level != kiosk.ConfigValidationWarning {
 			log.Fatal("Invalid configuration")

--- a/internal/config/config_validation.go
+++ b/internal/config/config_validation.go
@@ -368,6 +368,15 @@ func checkSchema(config map[string]any, level string) bool {
 		return true
 	}
 
+	// if we are using a config.yaml file but supplying immich_api_key || immich_url via ENVs get them
+	if v, ok := config["immich_api_key"]; !ok || v == "" {
+		config["immich_api_key"] = os.Getenv("KIOSK_IMMICH_API_KEY")
+	}
+
+	if v, ok := config["immich_url"]; !ok || v == "" {
+		config["immich_url"] = os.Getenv("KIOSK_IMMICH_URL")
+	}
+
 	jsonData, err := json.Marshal(config)
 	if err != nil {
 		log.Error("Failed to marshal config to JSON", "err", err)

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -1,6 +1,6 @@
 version: "3"
 env:
-  VERSION: 0.23.0-beta.2
+  VERSION: 0.23.1
 
 includes:
   frontend:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Configuration now accepts environment fallbacks for missing values: KIOSK_IMMICH_API_KEY and KIOSK_IMMICH_URL are used during validation if not set in the config.

- Bug Fixes
  - Improved config validation: the validation level is normalised, and invalid configurations now halt the app unless the level is set to warning, providing clearer feedback.

- Chores
  - Bumped version to 0.23.1, updating the embedded version in build artefacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->