### PR TITLE
Add NixOS flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1760524057,
+        "narHash": "sha256-EVAqOteLBFmd7pKkb0+FIUyzTF61VKi7YmvP1tw4nEw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "544961dfcce86422ba200ed9a0b00dd4b1486ec5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,38 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+    }:
+    let
+      system = "x86_64-linux";
+    in
+    {
+      devShells.${system}.default =
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+          };
+        in
+        pkgs.mkShellNoCC {
+          packages = with pkgs; [
+            # Go toolchain
+            go
+            gotools
+            gopls
+            go-task
+
+            # Frontend
+            nodejs
+            pnpm_9
+
+            # Templ for template generation
+            templ
+          ];
+        };
+    };
+}

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
+packages:
+  - "."
+
 onlyBuiltDependencies:
   - esbuild


### PR DESCRIPTION
NIxOS dev shell I used to build and test #555. Maybe useful for others.

Note, I was getting the following without the `pnpm` change:

```
ERROR  packages field missing or empty
For help, run: pnpm help run
```

(NB, immich-kiosk is [now available in nixpkgs](https://search.nixos.org/packages?channel=unstable&query=immich-kiosk) (via https://github.com/NixOS/nixpkgs/pull/451925))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated development environment setup to include Go, Node.js, and related tooling for local development
  * Configured package manager workspace structure to optimise dependency handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->