### PR TITLE
fix missing url-builder.js in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --prod --frozen-l
 # Frontend Build
 FROM frontend-base AS frontend-build
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
-RUN pnpm css && pnpm js
+RUN pnpm css && pnpm js && pnpm url-builder
 
 # Go Builder
 FROM --platform=$BUILDPLATFORM golang:1.25.4-alpine AS build


### PR DESCRIPTION
Thanks for getting the URL builder released!
I think there is an issue in the docker image as am getting a 404 for the url builder JS.

Adding this the url-builder pnpm build in docker file has fixed it for me - or as it's in the `build` of package.json we could just change this line to `pnpm build` although that will also run tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build process configuration to optimise the frontend build pipeline.

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->