### PR TITLE
fix: add missing 'secret' property to webhook schema

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -340,6 +340,9 @@
           },
           "event": {
             "type": "string"
+          },
+          "secret": {
+            "type": "string"
           }
         },
         "required": ["url", "event"]


### PR DESCRIPTION
The webhook struct supports a 'secret' field for HMAC signature
validation, but the JSON schema was missing this property causing
validation errors when users tried to configure it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Webhooks now support an optional secret field, providing an additional layer of authentication for your webhook configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->