### PR TITLE
feature/max-video-length

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -139,6 +139,11 @@
     "show_videos": {
       "type": "boolean"
     },
+    "exclude_videos_over": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Exclude videos over X seconds"
+    },
     "live_photos": {
       "type": "boolean"
     },

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -362,6 +362,8 @@ type Config struct {
 
 	// ShowVideos whether to display videos
 	ShowVideos bool `json:"showVideos" yaml:"show_videos" mapstructure:"show_videos" query:"show_videos" form:"show_videos" default:"false"`
+	// ExcludeVideosOver excludes videos longer than the specified duration in seconds. 0 means no limit.
+	ExcludeVideosOver int `json:"excludeVideosOver" yaml:"exclude_videos_over" mapstructure:"exclude_videos_over" query:"exclude_videos_over" form:"exclude_videos_over" default:"0"`
 	// LivePhotos show live photos
 	LivePhotos         bool `json:"livePhotos" yaml:"live_photos" mapstructure:"live_photos" query:"live_photos" form:"live_photos" default:"false"`
 	LivePhotoLoopDelay int  `json:"livePhotoLoopDelay" yaml:"live_photo_loop_delay" mapstructure:"live_photo_loop_delay" query:"live_photo_loop_delay" form:"live_photo_loop_delay" default:"0"`

--- a/internal/immich/immich_video.go
+++ b/internal/immich/immich_video.go
@@ -55,5 +55,15 @@ func (a *Asset) durationCheck() bool {
 	}
 	totalSeconds := hours*3600 + minutes*60 + seconds
 
-	return totalSeconds >= 1
+	// Ignore videos with duration less than one second
+	if totalSeconds < 1 {
+		return false
+	}
+
+	// Check maximum duration if configured
+	if a.requestConfig.ExcludeVideosOver > 0 && totalSeconds > a.requestConfig.ExcludeVideosOver {
+		return false
+	}
+
+	return true
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new configuration option to filter out videos longer than a specified duration. Users can now set a maximum video length threshold in seconds, with 0 indicating no filtering applied.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->