### PR TITLE
fix: change schema type from transition duration to float

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -205,10 +205,12 @@
       "type": "string"
     },
     "fade_transition_duration": {
-      "type": "integer"
+      "type": "number",
+      "minimum": 0
     },
     "cross_fade_transition_duration": {
-      "type": "integer"
+      "type": "number",
+      "minimum": 0
     },
     "show_clear_cache_button": {
       "type": "boolean"


### PR DESCRIPTION
As described in the documentation (https://docs.immichkiosk.app/configuration/behavior/#fade-transition-duration) and (https://docs.immichkiosk.app/configuration/behavior/#cross-fade-transition-duration) the value should be a float. Currently the schema validation only allows integers.

This PR just sets the correct type in the schema used for validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transition duration settings now accept decimal (number) values as well as integers and enforce non-negative values. This improves configuration flexibility for finer-grained timing, prevents invalid negative durations, and ensures consistent validation of transition-related settings across the app.

<sub>✏️ Tip: You can customise this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->