### PR TITLE
go bump to 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 RUN pnpm css && pnpm js && pnpm url-builder
 
 # Go Builder
-FROM --platform=$BUILDPLATFORM golang:1.25.7-bookworm AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.0-bookworm AS build
 
 ARG VERSION=demo
 ARG TARGETOS

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/damongolding/immich-kiosk
 
-go 1.25.7
+go 1.26.0
 
 require (
 	github.com/EdlinOrg/prominentcolor v1.0.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Go compiler to version 1.26.0 for the build environment, ensuring compatibility with the latest language toolchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->