### PR TITLE
fix/cap-focal-length

### DIFF
--- a/internal/templates/partials/metadata.templ
+++ b/internal/templates/partials/metadata.templ
@@ -165,7 +165,7 @@ func AssetExif(info immich.ExifInfo) string {
 		if stats.Len() > 0 {
 			stats.WriteString("<span class=\"asset--metadata--exif--seperator\">&#124;</span>")
 		}
-		fmt.Fprintf(&stats, "ISO %v", info.Iso)
+		fmt.Fprintf(&stats, "ISO %d", info.Iso)
 	}
 
 	return stats.String()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved image metadata display formatting—focal length now shows with two decimal places for greater precision, and ISO values now display as integers for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->