### PR TITLE
feat: add MQTT remote control with Home Assistant auto-discovery

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - "v*"
 
 env:
   REGISTRY: ghcr.io
@@ -57,4 +55,4 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            VERSION=${{ github.ref_name }}
+            VERSION=${{ github.sha }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,60 @@
+name: Build and publish Docker image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Set up QEMU (for multi-platform builds)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            VERSION=${{ github.ref_name }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,6 +11,9 @@ env:
 
 jobs:
   build-and-push:
+    concurrency:
+      group: docker-publish-${{ github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -174,4 +174,13 @@ kiosk:
   # mqtt_username: ""              # optional
   # mqtt_password: ""              # optional
   # mqtt_client_id: "immich-kiosk"
-  # mqtt_topic_prefix: "immich-kiosk"  # commands arrive on <prefix>/command
+  # mqtt_topic_prefix: "immich-kiosk"
+  #
+  # Commands are received on:
+  #   <prefix>/command                    -> all connected clients
+  #   <prefix>/<client>/command           -> a specific screen only
+  #
+  # Open the kiosk with ?client=<name> in the URL to enable per-screen control:
+  #   http://kiosk:3000/?client=living-room
+  #
+  # Home Assistant devices are created automatically via MQTT discovery.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -166,3 +166,12 @@ kiosk:
   cache: true # cache select api calls
   prefetch: true # fetch assets in the background
   asset_weighting: true # use weighting when picking assets
+
+  ## MQTT - remote control via e.g. Home Assistant
+  # mqtt_enabled: false
+  # mqtt_broker: "192.168.1.100"   # IP or hostname of the MQTT broker
+  # mqtt_port: 1883
+  # mqtt_username: ""              # optional
+  # mqtt_password: ""              # optional
+  # mqtt_client_id: "immich-kiosk"
+  # mqtt_topic_prefix: "immich-kiosk"  # commands arrive on <prefix>/command

--- a/config.schema.json
+++ b/config.schema.json
@@ -572,7 +572,9 @@
           "type": "string"
         },
         "mqtt_port": {
-          "type": "integer"
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
         },
         "mqtt_username": {
           "type": "string"
@@ -624,7 +626,16 @@
           }
         }
       },
-      "required": []
+      "required": [],
+      "if": {
+        "properties": { "mqtt_enabled": { "const": true } }
+      },
+      "then": {
+        "required": ["mqtt_broker"],
+        "properties": {
+          "mqtt_broker": { "type": "string", "minLength": 1 }
+        }
+      }
     }
   },
   "required": ["immich_api_key", "immich_url"]

--- a/config.schema.json
+++ b/config.schema.json
@@ -565,6 +565,27 @@
         "asset_weighting": {
           "type": "boolean"
         },
+        "mqtt_enabled": {
+          "type": "boolean"
+        },
+        "mqtt_broker": {
+          "type": "string"
+        },
+        "mqtt_port": {
+          "type": "integer"
+        },
+        "mqtt_username": {
+          "type": "string"
+        },
+        "mqtt_password": {
+          "type": "string"
+        },
+        "mqtt_client_id": {
+          "type": "string"
+        },
+        "mqtt_topic_prefix": {
+          "type": "string"
+        },
         "disable_url_queries": {
           "type": "boolean"
         },

--- a/frontend/src/ts/kiosk.ts
+++ b/frontend/src/ts/kiosk.ts
@@ -31,6 +31,7 @@ import {
 import { sleepMode } from "./sleep";
 import { preventSleep } from "./wakelock";
 import { weatherRotationPosition } from "./weather";
+import { initMqttSSE } from "./mqtt-sse";
 
 ("use strict");
 
@@ -215,6 +216,8 @@ async function init(): Promise<void> {
     addEventListeners();
 
     if (kioskData.livePhotos) livePhoto(kioskData.livePhotoLoopDelay);
+
+    initMqttSSE();
 
     // Burn-in prevention
     if (kioskData.burnInInterval > 0 && kioskData.burnInDuration > 0)

--- a/frontend/src/ts/mqtt-sse.ts
+++ b/frontend/src/ts/mqtt-sse.ts
@@ -14,8 +14,7 @@ type KioskCommand = "next" | "previous";
  */
 export function initMqttSSE(): void {
     const params = new URLSearchParams(window.location.search);
-    const client = params.get("client");
-    const url = client ? `/events?client=${encodeURIComponent(client)}` : "/events";
+    const url = params.toString() ? `/events?${params.toString()}` : "/events";
     const evtSource = new EventSource(url);
 
     evtSource.addEventListener("kiosk-command", (e: MessageEvent) => {

--- a/frontend/src/ts/mqtt-sse.ts
+++ b/frontend/src/ts/mqtt-sse.ts
@@ -1,0 +1,50 @@
+/**
+ * mqtt-sse.ts
+ * Listens to the /events SSE endpoint and translates incoming MQTT navigation
+ * commands into the HTMX events that the kiosk already understands.
+ */
+
+import htmx from "htmx.org";
+
+type KioskCommand = "next" | "previous";
+
+/**
+ * Initialises the SSE connection to /events.
+ * Must be called after the kiosk element is available in the DOM.
+ */
+export function initMqttSSE(): void {
+    const params = new URLSearchParams(window.location.search);
+    const client = params.get("client");
+    const url = client ? `/events?client=${encodeURIComponent(client)}` : "/events";
+    const evtSource = new EventSource(url);
+
+    evtSource.addEventListener("kiosk-command", (e: MessageEvent) => {
+        const cmd = (e.data as string).trim() as KioskCommand;
+
+        switch (cmd) {
+            case "next": {
+                const kioskEl = document.getElementById("kiosk");
+                if (kioskEl) {
+                    htmx.trigger(kioskEl, "kiosk-new-asset");
+                }
+                break;
+            }
+            case "previous": {
+                const prevEl = document.getElementById(
+                    "navigation-interaction-area--previous-asset",
+                );
+                if (prevEl) {
+                    htmx.trigger(prevEl, "kiosk-prev-asset");
+                }
+                break;
+            }
+            default:
+                console.warn("immich-kiosk: unknown MQTT command:", cmd);
+        }
+    });
+
+    evtSource.onerror = () => {
+        // Browser will automatically reconnect for EventSource; nothing extra needed.
+        console.debug("immich-kiosk: SSE connection error, will retry automatically");
+    };
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/a-h/templ v0.3.1001
 	github.com/disintegration/imaging v1.6.2
 	github.com/dustin/go-humanize v1.0.1
+	github.com/eclipse/paho.mqtt.golang v1.5.0
 	github.com/fogleman/gg v1.3.0
 	github.com/goodsign/monday v1.0.2
 	github.com/google/go-querystring v1.2.0
@@ -62,6 +63,7 @@ require (
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gohugoio/hugo v0.152.2 // indirect
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/mailru/easyjson v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,8 @@ github.com/dprotaso/go-yit v0.0.0-20250513224043-18a80f8f6df4 h1:JzpdVajvTuXQXL1
 github.com/dprotaso/go-yit v0.0.0-20250513224043-18a80f8f6df4/go.mod h1:lHwJo6jMevQL9tNpW6vLyhkK13bYHBcoh9tUakMhbnE=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/eclipse/paho.mqtt.golang v1.5.0 h1:EH+bUVJNgttidWFkLLVKaQPGmkTUfQQqjOsyvMGvD6o=
+github.com/eclipse/paho.mqtt.golang v1.5.0/go.mod h1:du/2qNQVqJf/Sqs4MEL77kR8QTqANF7XU7Fk0aOTAgk=
 github.com/evanw/esbuild v0.25.11 h1:NGtezc+xk+Mti4fgWaoD3dncZNCzcTA+r0BxMV3Koyw=
 github.com/evanw/esbuild v0.25.11/go.mod h1:D2vIQZqV/vIf/VRHtViaUtViZmG7o+kKmlBfVQuRi48=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
@@ -161,6 +163,8 @@ github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/css v1.0.1 h1:ntNaBIghp6JmvWnxbZKANoLyuXTPZ4cAMlo6RyhlbO8=
 github.com/gorilla/css v1.0.1/go.mod h1:BvnYkspnSzMmwRK+b8/xgNPLiIuNZr6vbZBTPQ2A3b0=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hairyhenderson/go-codeowners v0.7.0 h1:s0W4wF8bdsBEjTWzwzSlsatSthWtTAF2xLgo4a4RwAo=
 github.com/hairyhenderson/go-codeowners v0.7.0/go.mod h1:wUlNgQ3QjqC4z8DnM5nnCYVq/icpqXJyJOukKx5U8/Q=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -144,6 +144,22 @@ type KioskSettings struct {
 	DebugVerbose bool `json:"debugVerbose" yaml:"debug_verbose" mapstructure:"debug_verbose" default:"false"`
 
 	DemoMode bool `json:"-" yaml:"-" mapstructure:"demo_mode" default:"false"`
+
+	// MQTT settings
+	// MqttEnabled enables MQTT support for remote control (e.g. from Home Assistant)
+	MqttEnabled bool `json:"mqttEnabled" yaml:"mqtt_enabled" mapstructure:"mqtt_enabled" default:"false"`
+	// MqttBroker is the hostname or IP address of the MQTT broker
+	MqttBroker string `json:"mqttBroker" yaml:"mqtt_broker" mapstructure:"mqtt_broker" default:""`
+	// MqttPort is the port of the MQTT broker
+	MqttPort int `json:"mqttPort" yaml:"mqtt_port" mapstructure:"mqtt_port" default:"1883"`
+	// MqttUsername is the MQTT broker username (optional)
+	MqttUsername string `json:"mqttUsername" yaml:"mqtt_username" mapstructure:"mqtt_username" default:""`
+	// MqttPassword is the MQTT broker password (optional)
+	MqttPassword string `json:"-" yaml:"mqtt_password" mapstructure:"mqtt_password" default:"" redact:"true"`
+	// MqttClientID is the MQTT client identifier
+	MqttClientID string `json:"mqttClientId" yaml:"mqtt_client_id" mapstructure:"mqtt_client_id" default:"immich-kiosk"`
+	// MqttTopicPrefix is the MQTT topic prefix. Commands are received on <prefix>/command
+	MqttTopicPrefix string `json:"mqttTopicPrefix" yaml:"mqtt_topic_prefix" mapstructure:"mqtt_topic_prefix" default:"immich-kiosk"`
 }
 
 type WeatherConfig struct {
@@ -537,6 +553,13 @@ func bindEnvironmentVariables(v *viper.Viper) error {
 		{"kiosk.debug_verbose", "KIOSK_DEBUG_VERBOSE"},
 		{"kiosk.demo_mode", "KIOSK_DEMO_MODE"},
 		{"kiosk.config_validation_level", "KIOSK_CONFIG_VALIDATION_LEVEL"},
+		{"kiosk.mqtt_enabled", "KIOSK_MQTT_ENABLED"},
+		{"kiosk.mqtt_broker", "KIOSK_MQTT_BROKER"},
+		{"kiosk.mqtt_port", "KIOSK_MQTT_PORT"},
+		{"kiosk.mqtt_username", "KIOSK_MQTT_USERNAME"},
+		{"kiosk.mqtt_password", "KIOSK_MQTT_PASSWORD"},
+		{"kiosk.mqtt_client_id", "KIOSK_MQTT_CLIENT_ID"},
+		{"kiosk.mqtt_topic_prefix", "KIOSK_MQTT_TOPIC_PREFIX"},
 		{"offline_mode.enabled", "KIOSK_OFFLINE_MODE_ENABLED"},
 		{"offline_mode.number_of_assets", "KIOSK_OFFLINE_MODE_NUMBER_OF_ASSETS"},
 		{"offline_mode.max_size", "KIOSK_OFFLINE_MODE_MAX_SIZE"},

--- a/internal/mqtt/mqtt.go
+++ b/internal/mqtt/mqtt.go
@@ -149,10 +149,28 @@ func New(ctx context.Context, settings config.KioskSettings) (*Client, error) {
 	return c, nil
 }
 
+// isValidClientName returns true if clientName is safe to use as an MQTT
+// topic segment (non-empty, no '/', '#', or '+' characters).
+func isValidClientName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, ch := range name {
+		if ch == '/' || ch == '#' || ch == '+' {
+			return false
+		}
+	}
+	return true
+}
+
 // PublishClientDiscovery publishes HA MQTT Discovery for a named client
 // (e.g. "living-room"). Called automatically when a new client connects via SSE.
 func (c *Client) PublishClientDiscovery(clientName string) {
 	if clientName == "_global" {
+		return
+	}
+	if !isValidClientName(clientName) {
+		log.Warn("MQTT invalid client name, skipping discovery", "client", clientName)
 		return
 	}
 	uniqueID := "immich-kiosk-" + clientName

--- a/internal/mqtt/mqtt.go
+++ b/internal/mqtt/mqtt.go
@@ -1,0 +1,243 @@
+// Package mqtt provides MQTT client support for remote control of Immich Kiosk.
+//
+// On connect it publishes Home Assistant MQTT Discovery messages so the kiosk
+// appears automatically in Home Assistant. Each named client (e.g. ?client=living-room)
+// gets its own HA device with Next and Previous buttons, in addition to a global
+// device that controls all connected clients at once.
+//
+// MQTT topics:
+//
+//	<prefix>/command          – send command to ALL connected clients
+//	<prefix>/<client>/command – send command to a specific client only
+//	<prefix>/status           – availability (online/offline) for global device
+//	<prefix>/<client>/status  – availability for a specific client
+package mqtt
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"charm.land/log/v2"
+	pahomqtt "github.com/eclipse/paho.mqtt.golang"
+
+	"github.com/damongolding/immich-kiosk/internal/config"
+)
+
+// Command represents a navigation command received via MQTT.
+type Command string
+
+const (
+	CommandNext     Command = "next"
+	CommandPrevious Command = "previous"
+)
+
+// Handler is called when a valid command is received.
+// target is the client name the command is directed at, or "" for all clients.
+type Handler func(cmd Command, target string)
+
+// Client wraps the paho MQTT client.
+type Client struct {
+	client      pahomqtt.Client
+	handlers    []Handler
+	topic       string // global command topic
+	availTopic  string // global availability topic
+	topicPrefix string
+}
+
+// haDevice is the Home Assistant device block.
+type haDevice struct {
+	Identifiers  []string `json:"identifiers"`
+	Name         string   `json:"name"`
+	Model        string   `json:"model"`
+	Manufacturer string   `json:"manufacturer"`
+}
+
+// haButtonConfig is the HA MQTT Discovery payload for a button entity.
+type haButtonConfig struct {
+	Name              string   `json:"name"`
+	UniqueID          string   `json:"unique_id"`
+	CommandTopic      string   `json:"command_topic"`
+	PayloadPress      string   `json:"payload_press"`
+	AvailabilityTopic string   `json:"availability_topic"`
+	Device            haDevice `json:"device"`
+}
+
+// New creates and connects a new MQTT client.
+func New(ctx context.Context, settings config.KioskSettings) (*Client, error) {
+	broker := settings.MqttBroker
+	if broker == "" {
+		return nil, fmt.Errorf("mqtt_broker is not configured")
+	}
+
+	prefix := strings.TrimRight(settings.MqttTopicPrefix, "/")
+
+	c := &Client{
+		topic:       prefix + "/command",
+		availTopic:  prefix + "/status",
+		topicPrefix: prefix,
+	}
+
+	opts := pahomqtt.NewClientOptions()
+	opts.AddBroker(fmt.Sprintf("tcp://%s:%d", broker, settings.MqttPort))
+	opts.SetClientID(settings.MqttClientID)
+	opts.SetCleanSession(true)
+	opts.SetAutoReconnect(true)
+	opts.SetConnectRetry(true)
+	opts.SetConnectRetryInterval(10 * time.Second)
+	opts.SetKeepAlive(30 * time.Second)
+	opts.SetWill(c.availTopic, "offline", 1, true)
+
+	if settings.MqttUsername != "" {
+		opts.SetUsername(settings.MqttUsername)
+	}
+	if settings.MqttPassword != "" {
+		opts.SetPassword(settings.MqttPassword)
+	}
+
+	opts.SetOnConnectHandler(func(client pahomqtt.Client) {
+		log.Warn("MQTT connected", "broker", broker)
+
+		client.Publish(c.availTopic, 1, true, "online")
+
+		// Global discovery (controls all clients at once)
+		c.publishDiscovery(client, settings.MqttClientID, "", "Immich Kiosk (all)")
+
+		// Subscribe to global commands: immich-kiosk/command
+		if t := client.Subscribe(c.topic, 1, c.messageHandler); t.Wait() && t.Error() != nil {
+			log.Error("MQTT subscribe failed", "topic", c.topic, "err", t.Error())
+		} else {
+			log.Warn("MQTT subscribed", "topic", c.topic)
+		}
+
+		// Subscribe to per-client commands: immich-kiosk/+/command
+		wildcardTopic := prefix + "/+/command"
+		if t := client.Subscribe(wildcardTopic, 1, c.messageHandler); t.Wait() && t.Error() != nil {
+			log.Error("MQTT subscribe failed", "topic", wildcardTopic, "err", t.Error())
+		} else {
+			log.Warn("MQTT subscribed", "topic", wildcardTopic)
+		}
+	})
+
+	opts.SetConnectionLostHandler(func(client pahomqtt.Client, err error) {
+		log.Warn("MQTT connection lost", "err", err)
+	})
+
+	opts.SetReconnectingHandler(func(client pahomqtt.Client, opts *pahomqtt.ClientOptions) {
+		log.Warn("MQTT reconnecting...")
+	})
+
+	client := pahomqtt.NewClient(opts)
+	token := client.Connect()
+	token.Wait()
+	if err := token.Error(); err != nil {
+		return nil, fmt.Errorf("mqtt connect: %w", err)
+	}
+
+	c.client = client
+
+	go func() {
+		<-ctx.Done()
+		log.Warn("MQTT disconnecting")
+		c.client.Publish(c.availTopic, 1, true, "offline")
+		time.Sleep(200 * time.Millisecond)
+		client.Disconnect(500)
+	}()
+
+	return c, nil
+}
+
+// PublishClientDiscovery publishes HA MQTT Discovery for a named client
+// (e.g. "living-room"). Called automatically when a new client connects via SSE.
+func (c *Client) PublishClientDiscovery(clientName string) {
+	if clientName == "_global" {
+		return
+	}
+	uniqueID := "immich-kiosk-" + clientName
+	displayName := "Immich Kiosk - " + clientName
+	c.publishDiscovery(c.client, uniqueID, clientName, displayName)
+	log.Warn("MQTT client discovery published", "client", clientName)
+}
+
+// publishDiscovery publishes HA MQTT Discovery for Next and Previous buttons.
+// clientName="" means the global device (all clients).
+func (c *Client) publishDiscovery(client pahomqtt.Client, uniqueIDPrefix, clientName, deviceName string) {
+	var commandTopic string
+	if clientName == "" {
+		commandTopic = c.topic
+	} else {
+		commandTopic = fmt.Sprintf("%s/%s/command", c.topicPrefix, clientName)
+	}
+	// All entities share the global availability topic — only the server
+	// can reliably report online/offline (via LWT), not individual browsers.
+	availTopic := c.availTopic
+
+	device := haDevice{
+		Identifiers:  []string{uniqueIDPrefix},
+		Name:         deviceName,
+		Model:        "Immich Kiosk",
+		Manufacturer: "immich-kiosk",
+	}
+
+	buttons := []struct{ name, payload string }{
+		{"Next image", "next"},
+		{"Previous image", "previous"},
+	}
+
+	for _, b := range buttons {
+		discoveryTopic := fmt.Sprintf("homeassistant/button/%s/%s/config", uniqueIDPrefix, b.payload)
+		cfg := haButtonConfig{
+			Name:              b.name,
+			UniqueID:          uniqueIDPrefix + "-" + b.payload,
+			CommandTopic:      commandTopic,
+			PayloadPress:      b.payload,
+			AvailabilityTopic: availTopic,
+			Device:            device,
+		}
+		payload, err := json.Marshal(cfg)
+		if err != nil {
+			log.Error("MQTT discovery marshal failed", "err", err)
+			continue
+		}
+		client.Publish(discoveryTopic, 1, true, payload)
+	}
+}
+
+// AddHandler registers a handler called when a command is received.
+func (c *Client) AddHandler(h Handler) {
+	c.handlers = append(c.handlers, h)
+}
+
+// messageHandler processes incoming MQTT messages and determines target client.
+func (c *Client) messageHandler(_ pahomqtt.Client, msg pahomqtt.Message) {
+	topic := msg.Topic()
+	payload := strings.TrimSpace(strings.ToLower(string(msg.Payload())))
+	log.Debug("MQTT message received", "topic", topic, "payload", payload)
+
+	// Determine target client from topic structure:
+	// prefix/command          → target = "" (all)
+	// prefix/clientname/command → target = "clientname"
+	var target string
+	withoutPrefix := strings.TrimPrefix(topic, c.topicPrefix+"/")
+	if withoutPrefix != "command" {
+		// format is "<clientname>/command"
+		target = strings.TrimSuffix(withoutPrefix, "/command")
+	}
+
+	var cmd Command
+	switch payload {
+	case string(CommandNext):
+		cmd = CommandNext
+	case string(CommandPrevious):
+		cmd = CommandPrevious
+	default:
+		log.Warn("MQTT unknown command", "payload", payload)
+		return
+	}
+
+	for _, h := range c.handlers {
+		h(cmd, target)
+	}
+}

--- a/internal/mqtt/mqtt.go
+++ b/internal/mqtt/mqtt.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"charm.land/log/v2"
@@ -42,6 +43,7 @@ type Handler func(cmd Command, target string)
 type Client struct {
 	client      pahomqtt.Client
 	handlers    []Handler
+	handlersMu  sync.RWMutex
 	topic       string // global command topic
 	availTopic  string // global availability topic
 	topicPrefix string
@@ -225,7 +227,9 @@ func (c *Client) publishDiscovery(client pahomqtt.Client, uniqueIDPrefix, client
 
 // AddHandler registers a handler called when a command is received.
 func (c *Client) AddHandler(h Handler) {
+	c.handlersMu.Lock()
 	c.handlers = append(c.handlers, h)
+	c.handlersMu.Unlock()
 }
 
 // messageHandler processes incoming MQTT messages and determines target client.
@@ -255,7 +259,10 @@ func (c *Client) messageHandler(_ pahomqtt.Client, msg pahomqtt.Message) {
 		return
 	}
 
-	for _, h := range c.handlers {
+	c.handlersMu.RLock()
+	handlers := c.handlers
+	c.handlersMu.RUnlock()
+	for _, h := range handlers {
 		h(cmd, target)
 	}
 }

--- a/internal/routes/routes_manifest.go
+++ b/internal/routes/routes_manifest.go
@@ -30,6 +30,24 @@ type ManifestIcons struct {
 	Type  string `json:"type"`  // MIME type of the icon
 }
 
+// manifestStartURL builds a safe start_url from the referer, keeping only the
+// "client" query parameter so transient or sensitive params are not baked into
+// the installed PWA launch URL.
+func manifestStartURL(referer *url.URL) string {
+	startURL := referer.EscapedPath()
+	if startURL == "" {
+		startURL = "/"
+	}
+	filtered := url.Values{}
+	if client := referer.Query().Get("client"); client != "" {
+		filtered.Set("client", client)
+	}
+	if encoded := filtered.Encode(); encoded != "" {
+		startURL += "?" + encoded
+	}
+	return startURL
+}
+
 // Manifest generates and returns a web app manifest JSON response
 // based on the request referer URL. It sets appropriate headers
 // and formats the manifest data according to the Web App Manifest spec.
@@ -49,7 +67,7 @@ func Manifest(c *echo.Context) error {
 		Name:            "Immich Kiosk",
 		ShortName:       "Kiosk",
 		Description:     "Immich Kiosk is a lightweight slideshow for running on kiosk devices and browsers that uses Immich as a data source.",
-		StartURL:        referer.RequestURI(),
+		StartURL:        manifestStartURL(referer),
 		Scope:           "/",
 		Display:         "fullscreen",
 		BackgroundColor: "#000000",

--- a/internal/routes/routes_manifest.go
+++ b/internal/routes/routes_manifest.go
@@ -49,7 +49,7 @@ func Manifest(c *echo.Context) error {
 		Name:            "Immich Kiosk",
 		ShortName:       "Kiosk",
 		Description:     "Immich Kiosk is a lightweight slideshow for running on kiosk devices and browsers that uses Immich as a data source.",
-		StartURL:        referer.Path,
+		StartURL:        referer.RequestURI(),
 		Scope:           "/",
 		Display:         "fullscreen",
 		BackgroundColor: "#000000",

--- a/internal/routes/routes_sse.go
+++ b/internal/routes/routes_sse.go
@@ -62,6 +62,7 @@ func (h *SSEHub) unsubscribe(clientName string, ch chan string) {
 	delete(h.clients[clientName], ch)
 	if len(h.clients[clientName]) == 0 {
 		delete(h.clients, clientName)
+		delete(h.knownClients, clientName)
 	}
 	close(ch)
 }

--- a/internal/routes/routes_sse.go
+++ b/internal/routes/routes_sse.go
@@ -1,0 +1,154 @@
+package routes
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+
+	"charm.land/log/v2"
+	"github.com/labstack/echo/v5"
+
+	"github.com/damongolding/immich-kiosk/internal/config"
+	"github.com/damongolding/immich-kiosk/internal/mqtt"
+)
+
+// sseHub manages all active SSE client connections grouped by client name.
+var sseHub = &SSEHub{
+	clients:      make(map[string]map[chan string]struct{}),
+	knownClients: make(map[string]struct{}),
+}
+
+// SSEHub keeps track of connected SSE clients grouped by client name and
+// broadcasts events to them.
+type SSEHub struct {
+	mu           sync.RWMutex
+	clients      map[string]map[chan string]struct{} // clientName -> set of channels
+	knownClients map[string]struct{}                 // clients that have had HA discovery published
+	onNewClient  func(clientName string)             // called the first time a named client connects
+}
+
+// SetNewClientHandler registers a function to call when a new named client
+// connects for the first time (used to publish HA MQTT discovery).
+func (h *SSEHub) SetNewClientHandler(fn func(string)) {
+	h.mu.Lock()
+	h.onNewClient = fn
+	h.mu.Unlock()
+}
+
+// subscribe registers a new SSE channel for the given client name.
+func (h *SSEHub) subscribe(clientName string) chan string {
+	ch := make(chan string, 4)
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.clients[clientName] == nil {
+		h.clients[clientName] = make(map[chan string]struct{})
+	}
+	h.clients[clientName][ch] = struct{}{}
+
+	// Notify on first ever connection for this name
+	if _, known := h.knownClients[clientName]; !known && h.onNewClient != nil {
+		h.knownClients[clientName] = struct{}{}
+		go h.onNewClient(clientName)
+	}
+
+	return ch
+}
+
+// unsubscribe removes a channel from the hub.
+func (h *SSEHub) unsubscribe(clientName string, ch chan string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.clients[clientName], ch)
+	if len(h.clients[clientName]) == 0 {
+		delete(h.clients, clientName)
+	}
+	close(ch)
+}
+
+// broadcast sends an event to clients. If target is empty, all clients receive
+// the event. Otherwise only the named client group receives it.
+func (h *SSEHub) broadcast(target, event string) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	send := func(ch chan string) {
+		select {
+		case ch <- event:
+		default:
+			// client too slow, skip
+		}
+	}
+
+	if target == "" {
+		for _, channels := range h.clients {
+			for ch := range channels {
+				send(ch)
+			}
+		}
+		return
+	}
+
+	for ch := range h.clients[target] {
+		send(ch)
+	}
+}
+
+// SetNewClientHandler wires up a callback for when a new named client connects.
+func SetNewClientHandler(fn func(string)) {
+	sseHub.SetNewClientHandler(fn)
+}
+
+// MQTTCommandHandler returns an mqtt.Handler that broadcasts navigation commands
+// as SSE events to the correct client group (or all if target is empty).
+func MQTTCommandHandler() mqtt.Handler {
+	return func(cmd mqtt.Command, target string) {
+		log.Debug("MQTT command dispatched via SSE", "command", cmd, "target", target)
+		sseHub.broadcast(target, string(cmd))
+	}
+}
+
+// SSEEvents is an Echo handler that keeps an SSE connection open and streams
+// navigation commands to the browser. Pass ?client=<name> in the URL to
+// register the connection under a specific client name.
+func SSEEvents(_ *config.Config) echo.HandlerFunc {
+	return func(c *echo.Context) error {
+		w := c.Response()
+		r := c.Request()
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			return echo.NewHTTPError(http.StatusInternalServerError, "streaming not supported")
+		}
+
+		clientName := c.QueryParam("client")
+		if clientName == "" {
+			clientName = "_global"
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("X-Accel-Buffering", "no")
+		w.WriteHeader(http.StatusOK)
+
+		ch := sseHub.subscribe(clientName)
+		defer sseHub.unsubscribe(clientName, ch)
+
+		fmt.Fprintf(w, ": connected client=%s\n\n", clientName)
+		flusher.Flush()
+
+		for {
+			select {
+			case <-r.Context().Done():
+				return nil
+			case event, ok := <-ch:
+				if !ok {
+					return nil
+				}
+				fmt.Fprintf(w, "event: kiosk-command\ndata: %s\n\n", event)
+				flusher.Flush()
+			}
+		}
+	}
+}

--- a/internal/routes/routes_sse.go
+++ b/internal/routes/routes_sse.go
@@ -3,6 +3,7 @@ package routes
 import (
 	"fmt"
 	"net/http"
+	"regexp"
 	"sync"
 	"time"
 
@@ -20,7 +21,22 @@ const (
 
 	// ssePendingTTL how long a queued command waits for a client to reconnect.
 	ssePendingTTL = 10 * time.Second
+
+	// sseClientNameMaxLen maximum allowed length for a client name.
+	sseClientNameMaxLen = 32
 )
+
+// sseClientNameRe matches valid SSE client names: letters, digits, hyphens, underscores.
+var sseClientNameRe = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+
+// validSSEClientName returns the sanitised client name, or "_global" if the
+// name is empty, too long, or contains disallowed characters.
+func validSSEClientName(name string) string {
+	if name == "" || len(name) > sseClientNameMaxLen || !sseClientNameRe.MatchString(name) {
+		return "_global"
+	}
+	return name
+}
 
 // sseHub manages all active SSE client connections grouped by client name.
 var sseHub = &SSEHub{
@@ -66,19 +82,24 @@ func (h *SSEHub) subscribe(clientName string) chan string {
 	h.clients[clientName][ch] = struct{}{}
 
 	// Deliver a pending command if it hasn't expired yet.
-	// Check both a client-specific command and a global broadcast command.
+	// Check per-client first, then fall back to the global broadcast slot.
+	// The global slot is NOT deleted here so that other reconnecting clients
+	// can also receive it; it is cleaned up lazily in broadcast() once expired.
 	now := time.Now()
-	for _, key := range []string{clientName, ""} {
-		if p, ok := h.pending[key]; ok {
-			if now.Before(p.expires) {
-				select {
-				case ch <- p.event:
-				default:
-				}
+	if p, ok := h.pending[clientName]; ok {
+		if now.Before(p.expires) {
+			select {
+			case ch <- p.event:
+			default:
 			}
-			delete(h.pending, key)
-			break
 		}
+		delete(h.pending, clientName)
+	} else if p, ok := h.pending[""]; ok && now.Before(p.expires) {
+		select {
+		case ch <- p.event:
+		default:
+		}
+		// Do NOT delete pending[""] — other clients need it too.
 	}
 
 	// Notify on first ever connection for this name.
@@ -109,11 +130,18 @@ func (h *SSEHub) broadcast(target, event string) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	send := func(ch chan string) {
+	// Purge any expired global pending entry.
+	if p, ok := h.pending[""]; ok && !time.Now().Before(p.expires) {
+		delete(h.pending, "")
+	}
+
+	// send attempts a non-blocking channel send and returns true if delivered.
+	send := func(ch chan string) bool {
 		select {
 		case ch <- event:
+			return true
 		default:
-			// client too slow, skip
+			return false
 		}
 	}
 
@@ -122,8 +150,9 @@ func (h *SSEHub) broadcast(target, event string) {
 	if target == "" {
 		for _, channels := range h.clients {
 			for ch := range channels {
-				send(ch)
-				delivered = true
+				if send(ch) {
+					delivered = true
+				}
 			}
 		}
 		// Queue globally: store under empty-string key so any reconnecting
@@ -135,8 +164,9 @@ func (h *SSEHub) broadcast(target, event string) {
 	}
 
 	for ch := range h.clients[target] {
-		send(ch)
-		delivered = true
+		if send(ch) {
+			delivered = true
+		}
 	}
 	if !delivered {
 		h.pending[target] = pendingCmd{event: event, expires: time.Now().Add(ssePendingTTL)}
@@ -173,10 +203,7 @@ func SSEEvents(_ *config.Config) echo.HandlerFunc {
 			return echo.NewHTTPError(http.StatusInternalServerError, "streaming not supported")
 		}
 
-		clientName := c.QueryParam("client")
-		if clientName == "" {
-			clientName = "_global"
-		}
+		clientName := validSSEClientName(c.QueryParam("client"))
 
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.Header().Set("Cache-Control", "no-cache")

--- a/internal/routes/routes_sse.go
+++ b/internal/routes/routes_sse.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"time"
 
 	"charm.land/log/v2"
 	"github.com/labstack/echo/v5"
@@ -12,10 +13,26 @@ import (
 	"github.com/damongolding/immich-kiosk/internal/mqtt"
 )
 
+const (
+	// sseHeartbeatInterval how often a keepalive comment is sent to prevent
+	// proxies and iOS from closing the idle SSE connection.
+	sseHeartbeatInterval = 30 * time.Second
+
+	// ssePendingTTL how long a queued command waits for a client to reconnect.
+	ssePendingTTL = 10 * time.Second
+)
+
 // sseHub manages all active SSE client connections grouped by client name.
 var sseHub = &SSEHub{
 	clients:      make(map[string]map[chan string]struct{}),
 	knownClients: make(map[string]struct{}),
+	pending:      make(map[string]pendingCmd),
+}
+
+// pendingCmd holds a command that arrived when no client was connected.
+type pendingCmd struct {
+	event   string
+	expires time.Time
 }
 
 // SSEHub keeps track of connected SSE clients grouped by client name and
@@ -24,6 +41,7 @@ type SSEHub struct {
 	mu           sync.RWMutex
 	clients      map[string]map[chan string]struct{} // clientName -> set of channels
 	knownClients map[string]struct{}                 // clients that have had HA discovery published
+	pending      map[string]pendingCmd               // commands waiting for a client to reconnect
 	onNewClient  func(clientName string)             // called the first time a named client connects
 }
 
@@ -35,7 +53,8 @@ func (h *SSEHub) SetNewClientHandler(fn func(string)) {
 	h.mu.Unlock()
 }
 
-// subscribe registers a new SSE channel for the given client name.
+// subscribe registers a new SSE channel for the given client name and
+// delivers any queued command that arrived while the client was disconnected.
 func (h *SSEHub) subscribe(clientName string) chan string {
 	ch := make(chan string, 4)
 	h.mu.Lock()
@@ -46,7 +65,23 @@ func (h *SSEHub) subscribe(clientName string) chan string {
 	}
 	h.clients[clientName][ch] = struct{}{}
 
-	// Notify on first ever connection for this name
+	// Deliver a pending command if it hasn't expired yet.
+	// Check both a client-specific command and a global broadcast command.
+	now := time.Now()
+	for _, key := range []string{clientName, ""} {
+		if p, ok := h.pending[key]; ok {
+			if now.Before(p.expires) {
+				select {
+				case ch <- p.event:
+				default:
+				}
+			}
+			delete(h.pending, key)
+			break
+		}
+	}
+
+	// Notify on first ever connection for this name.
 	if _, known := h.knownClients[clientName]; !known && h.onNewClient != nil {
 		h.knownClients[clientName] = struct{}{}
 		go h.onNewClient(clientName)
@@ -68,10 +103,11 @@ func (h *SSEHub) unsubscribe(clientName string, ch chan string) {
 }
 
 // broadcast sends an event to clients. If target is empty, all clients receive
-// the event. Otherwise only the named client group receives it.
+// the event. If no client is currently connected the command is queued briefly
+// so it can be delivered when the client reconnects.
 func (h *SSEHub) broadcast(target, event string) {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
+	h.mu.Lock()
+	defer h.mu.Unlock()
 
 	send := func(ch chan string) {
 		select {
@@ -81,17 +117,29 @@ func (h *SSEHub) broadcast(target, event string) {
 		}
 	}
 
+	delivered := false
+
 	if target == "" {
 		for _, channels := range h.clients {
 			for ch := range channels {
 				send(ch)
+				delivered = true
 			}
+		}
+		// Queue globally: store under empty-string key so any reconnecting
+		// client (regardless of name) picks it up.
+		if !delivered {
+			h.pending[""] = pendingCmd{event: event, expires: time.Now().Add(ssePendingTTL)}
 		}
 		return
 	}
 
 	for ch := range h.clients[target] {
 		send(ch)
+		delivered = true
+	}
+	if !delivered {
+		h.pending[target] = pendingCmd{event: event, expires: time.Now().Add(ssePendingTTL)}
 	}
 }
 
@@ -112,6 +160,9 @@ func MQTTCommandHandler() mqtt.Handler {
 // SSEEvents is an Echo handler that keeps an SSE connection open and streams
 // navigation commands to the browser. Pass ?client=<name> in the URL to
 // register the connection under a specific client name.
+//
+// A heartbeat comment is sent every 30 s to prevent proxies and iOS from
+// closing the idle connection.
 func SSEEvents(_ *config.Config) echo.HandlerFunc {
 	return func(c *echo.Context) error {
 		w := c.Response()
@@ -139,10 +190,16 @@ func SSEEvents(_ *config.Config) echo.HandlerFunc {
 		fmt.Fprintf(w, ": connected client=%s\n\n", clientName)
 		flusher.Flush()
 
+		heartbeat := time.NewTicker(sseHeartbeatInterval)
+		defer heartbeat.Stop()
+
 		for {
 			select {
 			case <-r.Context().Done():
 				return nil
+			case <-heartbeat.C:
+				fmt.Fprintf(w, ": heartbeat\n\n")
+				flusher.Flush()
 			case event, ok := <-ch:
 				if !ok {
 					return nil

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/damongolding/immich-kiosk/internal/cache"
 	"github.com/damongolding/immich-kiosk/internal/common"
 	"github.com/damongolding/immich-kiosk/internal/config"
+	"github.com/damongolding/immich-kiosk/internal/mqtt"
 	"github.com/damongolding/immich-kiosk/internal/i18n"
 	"github.com/damongolding/immich-kiosk/internal/immich"
 	"github.com/damongolding/immich-kiosk/internal/routes"
@@ -119,6 +120,17 @@ func main() {
 		baseConfig.WatchConfig(c.Context())
 	}
 
+	if baseConfig.Kiosk.MqttEnabled {
+		mqttClient, mqttErr := mqtt.New(c.Context(), baseConfig.Kiosk)
+		if mqttErr != nil {
+			log.Error("Failed to connect to MQTT broker", "err", mqttErr)
+		} else {
+			mqttClient.AddHandler(routes.MQTTCommandHandler())
+			routes.SetNewClientHandler(mqttClient.PublishClientDiscovery)
+			log.Warn("MQTT enabled", "broker", baseConfig.Kiosk.MqttBroker, "topic_prefix", baseConfig.Kiosk.MqttTopicPrefix)
+		}
+	}
+
 	if baseConfig.Kiosk.Debug {
 		log.SetLevel(log.DebugLevel)
 		if baseConfig.Kiosk.DebugVerbose {
@@ -162,6 +174,8 @@ func main() {
 	e.GET("/health", func(c *echo.Context) error {
 		return c.String(http.StatusOK, "OK")
 	})
+
+	e.GET("/events", routes.SSEEvents(baseConfig))
 
 	if baseConfig.Kiosk.EnableURLBuilder {
 		e.GET("/url-builder", routes.URLBuilderPage(baseConfig, c, false))
@@ -260,7 +274,7 @@ func addMiddleware(e *echo.Echo, baseConfig *config.Config) {
 	e.Use(middleware.GzipWithConfig(middleware.GzipConfig{
 		Level: 6,
 		Skipper: func(c *echo.Context) bool {
-			return strings.Contains(c.Path(), "image")
+			return strings.Contains(c.Path(), "image") || c.Path() == "/events"
 		},
 	}))
 


### PR DESCRIPTION
## Add MQTT remote control with Home Assistant auto-discovery

### Summary

This PR adds MQTT-based remote control to Immich Kiosk, enabling integration with Home Assistant and other MQTT-capable systems. It also fixes a PWA bug where iOS strips query parameters when adding to the home screen.

### How MQTT control works

The kiosk connects to a configured MQTT broker and subscribes to command topics. Commands are forwarded to connected browsers via Server-Sent Events (SSE), which trigger the existing HTMX navigation — no polling, no page reload.

**Supported commands:** `next` / `previous`

**Topics:**
```
<prefix>/command              → all connected clients
<prefix>/<client>/command     → a specific screen only
```

**Per-screen targeting:** Open the kiosk with `?client=living-room` in the URL. Each named client gets its own MQTT topic and its own device in Home Assistant.

### Home Assistant auto-discovery

On connect, the kiosk publishes MQTT Discovery messages so it appears automatically in HA as a device with Next and Previous buttons — no manual HA configuration needed. Availability (online/offline) is handled via MQTT Last Will and Testament.

### Configuration

```yaml
kiosk:
  mqtt_enabled: true
  mqtt_broker: "192.168.1.x"
  mqtt_port: 1883
  mqtt_username: ""        # optional
  mqtt_password: ""        # optional
  mqtt_client_id: "immich-kiosk"
  mqtt_topic_prefix: "immich-kiosk"
```

All settings are also available as environment variables (`KIOSK_MQTT_ENABLED`, `KIOSK_MQTT_BROKER` etc).

### PWA fix

`start_url` in the web app manifest now includes query parameters, so `?client=living-room` is preserved when the page is added to the iOS home screen.

### Changes

- `internal/mqtt/` — new package: MQTT client, HA discovery, LWT
- `internal/routes/routes_sse.go` — SSE hub grouped by client name
- `frontend/src/ts/mqtt-sse.ts` — EventSource listener → HTMX triggers
- `internal/config/config.go` + `config.schema.json` — new MQTT settings
- `internal/routes/routes_manifest.go` — PWA manifest fix
- `config.example.yaml` — documented MQTT options

**Dependency added:** `github.com/eclipse/paho.mqtt.golang`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MQTT-based remote control for kiosk navigation (next/previous) with Home Assistant discovery.
  * Real-time server-sent events (SSE) endpoint and hub for broadcasting and queuing commands.
  * Frontend SSE integration and optional commented MQTT kiosk settings plus schema validation.

* **Bug Fixes**
  * Manifest start URL now preserves relevant client query parameter for correct start behaviour.

* **Chores**
  * Automated multi-architecture Docker build & publish workflow for main branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->