### PR TITLE
feat(weather): add temperature range display

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -133,6 +133,11 @@ hide_button_action: tag # tag, archive, or both [tag, archive]
 #       lang: en
 #       forecast: false
 #       default: false
+#       show:
+#         humidity: false
+#         wind: false
+#         visibility: false
+#         temperature_range: false
 
 ## Add iframes into Kiosk - you can use local files or remote URLs
 #iframe:

--- a/config.schema.json
+++ b/config.schema.json
@@ -433,6 +433,11 @@
                     "type": "boolean",
                     "description": "Show the current visibility",
                     "default": false
+                  },
+                  "temperature_range": {
+                    "type": "boolean",
+                    "description": "Show the next 24-hour forecast high/low temperature (requires forecast: true)",
+                    "default": false
                   }
                 }
               },

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -156,9 +156,10 @@ type WeatherConfig struct {
 }
 
 type WeatherLocationStatOptions struct {
-	Humidity   bool `yaml:"humidity" mapstructure:"humidity" default:"false"`
-	Wind       bool `yaml:"wind" mapstructure:"wind" default:"false"`
-	Visibility bool `yaml:"visibility" mapstructure:"visibility" default:"false"`
+	Humidity         bool `yaml:"humidity" mapstructure:"humidity" default:"false"`
+	Wind             bool `yaml:"wind" mapstructure:"wind" default:"false"`
+	Visibility       bool `yaml:"visibility" mapstructure:"visibility" default:"false"`
+	TemperatureRange bool `yaml:"temperature_range" mapstructure:"temperature_range" default:"false"`
 }
 
 type WeatherLocation struct {

--- a/internal/templates/partials/weather.templ
+++ b/internal/templates/partials/weather.templ
@@ -151,10 +151,25 @@ templ WeatherLocation(weatherData weather.Location, locationPos int, systemLang 
 					</div>
 				</div>
 			}
+			if weatherData.Show.TemperatureRange && len(weatherData.Forecast.Daily) > 0 {
+				<div class="weather--stat weather--temperature-range">
+					<div class="weather--stat--value weather--temperature-range--value">
+						↗{ formatTemp(weatherData.Forecast.Next24hHigh, weatherData.RoundTemp) }°
+						<span class="asset--metadata--exif--seperator">&#124;</span>
+						↘{ formatTemp(weatherData.Forecast.Next24hLow, weatherData.RoundTemp) }°
+					</div>
+					<div class="weather--stat--icon weather--temperature-range--icon">
+						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512">
+							<!--!Font Awesome Free v7.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.-->
+							<path d="M160 0C107 0 64 43 64 96l0 164.7C34.5 287 16 325.4 16 368 16 447.5 80.5 512 160 512s144-64.5 144-144c0-42.6-18.5-81-48-107.3L256 96c0-53-43-96-96-96zm64 368c0 35.3-28.7 64-64 64s-64-28.7-64-64c0-26.9 16.5-49.9 40-59.3l0-92.7c0-13.3 10.7-24 24-24s24 10.7 24 24l0 92.7c23.5 9.5 40 32.5 40 59.3z"></path>
+						</svg>
+					</div>
+				</div>
+			}
 		</div>
-		if len(weatherData.Forecast) > 0 {
+		if len(weatherData.Forecast.Daily) > 0 {
 			<div class="weather--forecast">
-				for _, f := range weatherData.Forecast {
+				for _, f := range weatherData.Forecast.Daily {
 					{{ forecastDay := monday.Format(f.Date, "Mon", systemLang) }}
 					<div class="weather--forecast--item">
 						<div>{ forecastDay }</div>

--- a/internal/templates/partials/weather.templ
+++ b/internal/templates/partials/weather.templ
@@ -106,6 +106,21 @@ templ WeatherLocation(weatherData weather.Location, locationPos int, systemLang 
 					</div>
 				</div>
 			}
+			if weatherData.Show.TemperatureRange && len(weatherData.Forecast.Daily) > 0 {
+				<div class="weather--stat weather--temperature-range">
+					<div class="weather--stat--value weather--temperature-range--value">
+						{ formatTemp(weatherData.Forecast.Next24hHigh, weatherData.RoundTemp) }°
+						<span class="asset--metadata--exif--seperator">&#124;</span>
+						{ formatTemp(weatherData.Forecast.Next24hLow, weatherData.RoundTemp) }°
+					</div>
+					<div class="weather--stat--icon weather--temperature-range--icon">
+						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512">
+							<!--!Font Awesome Free v7.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.-->
+							<path d="M160 0C107 0 64 43 64 96l0 164.7C34.5 287 16 325.4 16 368 16 447.5 80.5 512 160 512s144-64.5 144-144c0-42.6-18.5-81-48-107.3L256 96c0-53-43-96-96-96zm64 368c0 35.3-28.7 64-64 64s-64-28.7-64-64c0-26.9 16.5-49.9 40-59.3L136 96c0-13.3 10.7-24 24-24s24 10.7 24 24l0 212.7c23.5 9.5 40 32.5 40 59.3z"></path>
+						</svg>
+					</div>
+				</div>
+			}
 			if weatherData.Show.Humidity {
 				<div class="weather--stat weather--humidity">
 					<div class="weather--stat--value weather--humidity--value">
@@ -147,21 +162,6 @@ templ WeatherLocation(weatherData weather.Location, locationPos int, systemLang 
 						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512">
 							<!--!Font Awesome Free v7.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.-->
 							<path d="M288 32c-80.8 0-145.5 36.8-192.6 80.6-46.8 43.5-78.1 95.4-93 131.1-3.3 7.9-3.3 16.7 0 24.6 14.9 35.7 46.2 87.7 93 131.1 47.1 43.7 111.8 80.6 192.6 80.6s145.5-36.8 192.6-80.6c46.8-43.5 78.1-95.4 93-131.1 3.3-7.9 3.3-16.7 0-24.6-14.9-35.7-46.2-87.7-93-131.1-47.1-43.7-111.8-80.6-192.6-80.6zM144 256a144 144 0 1 1 288 0 144 144 0 1 1 -288 0zm144-64c0 35.3-28.7 64-64 64-11.5 0-22.3-3-31.7-8.4-1 10.9-.1 22.1 2.9 33.2 13.7 51.2 66.4 81.6 117.6 67.9s81.6-66.4 67.9-117.6c-12.2-45.7-55.5-74.8-101.1-70.8 5.3 9.3 8.4 20.1 8.4 31.7z"></path>
-						</svg>
-					</div>
-				</div>
-			}
-			if weatherData.Show.TemperatureRange && len(weatherData.Forecast.Daily) > 0 {
-				<div class="weather--stat weather--temperature-range">
-					<div class="weather--stat--value weather--temperature-range--value">
-						↗{ formatTemp(weatherData.Forecast.Next24hHigh, weatherData.RoundTemp) }°
-						<span class="asset--metadata--exif--seperator">&#124;</span>
-						↘{ formatTemp(weatherData.Forecast.Next24hLow, weatherData.RoundTemp) }°
-					</div>
-					<div class="weather--stat--icon weather--temperature-range--icon">
-						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512">
-							<!--!Font Awesome Free v7.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.-->
-							<path d="M160 0C107 0 64 43 64 96l0 164.7C34.5 287 16 325.4 16 368 16 447.5 80.5 512 160 512s144-64.5 144-144c0-42.6-18.5-81-48-107.3L256 96c0-53-43-96-96-96zm64 368c0 35.3-28.7 64-64 64s-64-28.7-64-64c0-26.9 16.5-49.9 40-59.3l0-92.7c0-13.3 10.7-24 24-24s24 10.7 24 24l0 92.7c23.5 9.5 40 32.5 40 59.3z"></path>
 						</svg>
 					</div>
 				</div>

--- a/internal/weather/weather.go
+++ b/internal/weather/weather.go
@@ -98,6 +98,12 @@ func (s *LocationRotate) Next(i int) (int, string) {
 
 var LocationRotator = &LocationRotate{}
 
+type ForecastData struct {
+	Daily       []DailySummary
+	Next24hHigh float64
+	Next24hLow  float64
+}
+
 type Location struct {
 	Name      string
 	Lat       string
@@ -106,7 +112,7 @@ type Location struct {
 	Unit      string
 	Lang      string
 	Show      config.WeatherLocationStatOptions
-	Forecast  []DailySummary
+	Forecast  ForecastData
 	RoundTemp bool
 	Weather
 }
@@ -400,7 +406,7 @@ func (w *Location) updateForecast(ctx context.Context) (Location, error) {
 	return *w, nil
 }
 
-func processForecast(forecast Forecast, tzOffsetSeconds int) []DailySummary {
+func processForecast(forecast Forecast, tzOffsetSeconds int) ForecastData {
 	loc := time.FixedZone("owm", tzOffsetSeconds)
 	// Today’s date at midnight in location zone
 	now := time.Now().In(loc)
@@ -470,6 +476,40 @@ func processForecast(forecast Forecast, tzOffsetSeconds int) []DailySummary {
 	})
 
 	n := min(3, len(summaries))
-	return summaries[:n]
+	high, low := computeNext24hTempRange(forecast)
+	return ForecastData{
+		Daily:       summaries[:n],
+		Next24hHigh: high,
+		Next24hLow:  low,
+	}
+}
 
+// computeNext24hTempRange scans the next 24 hours of forecast intervals and returns
+// the highest TempMax and lowest TempMin found. This gives a rolling "high/low for
+// the next 24 hours" that is always meaningful regardless of time of day.
+func computeNext24hTempRange(forecast Forecast) (float64, float64) {
+	now := time.Now()
+	cutoff := now.Add(24 * time.Hour)
+
+	var high, low float64
+	initialized := false
+	for _, item := range forecast.List {
+		itemTime := time.Unix(item.DT, 0)
+		if itemTime.Before(now) || itemTime.After(cutoff) {
+			continue
+		}
+		if !initialized {
+			high = item.Main.TempMax
+			low = item.Main.TempMin
+			initialized = true
+		} else {
+			if item.Main.TempMax > high {
+				high = item.Main.TempMax
+			}
+			if item.Main.TempMin < low {
+				low = item.Main.TempMin
+			}
+		}
+	}
+	return high, low
 }

--- a/internal/weather/weather_test.go
+++ b/internal/weather/weather_test.go
@@ -1,0 +1,86 @@
+package weather
+
+import (
+	"testing"
+	"time"
+)
+
+// makeWeather is a test helper for building Forecast.List entries.
+func makeWeather(unixSec int64, tempMax, tempMin float64) Weather {
+	return Weather{
+		DT:   unixSec,
+		Main: Main{TempMax: tempMax, TempMin: tempMin},
+	}
+}
+
+func TestComputeNext24hTempRange(t *testing.T) {
+	now := time.Now()
+
+	hour := func(offset float64) int64 {
+		return now.Add(time.Duration(offset * float64(time.Hour))).Unix()
+	}
+
+	tests := []struct {
+		name     string
+		forecast Forecast
+		wantHigh float64
+		wantLow  float64
+	}{
+		{
+			name: "single interval within window",
+			forecast: Forecast{List: []Weather{
+				makeWeather(hour(1), 20.0, 10.0),
+			}},
+			wantHigh: 20.0,
+			wantLow:  10.0,
+		},
+		{
+			name: "multiple intervals – picks max high and min low",
+			forecast: Forecast{List: []Weather{
+				makeWeather(hour(1), 18.0, 12.0),
+				makeWeather(hour(6), 25.0, 8.0),
+				makeWeather(hour(12), 22.0, 10.0),
+			}},
+			wantHigh: 25.0,
+			wantLow:  8.0,
+		},
+		{
+			name: "intervals outside window are ignored",
+			forecast: Forecast{List: []Weather{
+				makeWeather(hour(-3), 99.0, -99.0), // 3h in the past
+				makeWeather(hour(1), 20.0, 10.0),   // within window
+				makeWeather(hour(25), 99.0, -99.0), // 25h in the future
+			}},
+			wantHigh: 20.0,
+			wantLow:  10.0,
+		},
+		{
+			name:     "empty forecast returns zero values",
+			forecast: Forecast{List: []Weather{}},
+			wantHigh: 0,
+			wantLow:  0,
+		},
+		{
+			name: "all intervals outside window returns zero values",
+			forecast: Forecast{List: []Weather{
+				makeWeather(hour(-5), 30.0, 5.0), // past
+				makeWeather(hour(25), 28.0, 6.0), // beyond 24h
+			}},
+			wantHigh: 0,
+			wantLow:  0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			high, low := computeNext24hTempRange(tc.forecast)
+			if high != tc.wantHigh {
+				t.Errorf("high = %v, want %v", high, tc.wantHigh)
+			}
+			if low != tc.wantLow {
+				t.Errorf("low = %v, want %v", low, tc.wantLow)
+			}
+		})
+	}
+}
+


### PR DESCRIPTION
Adds next 24 hour temperature range alongside existing weather stats.

## How it works

When forecast data is being processed, find max and min temp in the next 24 hours.

- **Rolling 24-hour window** rather than calendar-day high/low, so the values stay meaningful at any time of
day.
- **Diagonal arrows** chosen over H/L labels for visual clarity at kiosk viewing distance
- **`ForecastData` struct** groups daily summaries, 24h high, and 24h low together — `processForecast` now
returns this directly so all forecast-derived state lives in one place

## Config

Added a new config under `weather.locations.show.temperature_range` to toggle the display of the data.

```yaml
weather:
  locations:
    - name: london
      lat: 51.5285262
      lon: -0.2663999
      api: ""
      unit: metric
      forecast: true
      show:
        temperature_range: true
```

## Changes

- Added a method to compute next 24h temp range in `weather.go`
- expanded `Forecast` field from `[]Daily` to a new `ForecastData` type, which also includes next 24h high and low temp.
- Added a new config under `weather.locations.show.temperature_range` to toggle the display
- Modified weather.templ to include the new values

Preview

![chrome_TyZMrc2ucS](https://github.com/user-attachments/assets/223b0aee-3f30-4259-aa56-4450f2126f0d)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Weather display: optional temperature-range stat showing next 24‑hour high/low with its own visual indicator.

* **Configuration**
  * New per-location `temperature_range` toggle under weather display settings (off by default; requires forecast mode).

* **Tests**
  * Added unit tests validating computation of the next 24‑hour temperature range under various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->