### PR TITLE
feat: Added support for wind direction displayed as compass heading

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -451,6 +451,11 @@
                     "description": "Show the current wind speed",
                     "default": false
                   },
+                  "wind_direction": {
+                    "type": "boolean",
+                    "description": "Show wind direction as a compass heading (N, NE, E, etc.) instead of degrees",
+                    "default": false
+                  },
                   "visibility": {
                     "type": "boolean",
                     "description": "Show the current visibility",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -158,6 +158,7 @@ type WeatherConfig struct {
 type WeatherLocationStatOptions struct {
 	Humidity         bool `yaml:"humidity" mapstructure:"humidity" default:"false"`
 	Wind             bool `yaml:"wind" mapstructure:"wind" default:"false"`
+	WindDirection    bool `yaml:"wind_direction" mapstructure:"wind_direction" default:"false"`
 	Visibility       bool `yaml:"visibility" mapstructure:"visibility" default:"false"`
 	TemperatureRange bool `yaml:"temperature_range" mapstructure:"temperature_range" default:"false"`
 }

--- a/internal/templates/partials/weather.templ
+++ b/internal/templates/partials/weather.templ
@@ -142,7 +142,11 @@ templ WeatherLocation(weatherData weather.Location, locationPos int, systemLang 
 								windUnit = "mph"
 							}
 						}}
-						{ weatherData.Wind.Deg }&deg;<span class="asset--metadata--exif--seperator">&#124;</span>{ weatherData.Wind.Speed }{ windUnit }
+						if weatherData.Show.WindDirection {
+							{ weatherData.Wind.CompassDirection() }<span class="asset--metadata--exif--seperator">&#124;</span>{ weatherData.Wind.Speed }{ windUnit }
+						} else {
+							{ weatherData.Wind.Deg }&deg;<span class="asset--metadata--exif--seperator">&#124;</span>{ weatherData.Wind.Speed }{ windUnit }
+						}
 					</div>
 					<div class="weather--stat--icon weather--wind--icon">
 						@weatherIcon(771)

--- a/internal/weather/weather.go
+++ b/internal/weather/weather.go
@@ -178,6 +178,9 @@ type Wind struct {
 func (w Wind) CompassDirection() string {
 	directions := []string{"N", "NE", "E", "SE", "S", "SW", "W", "NW"}
 	idx := int(math.Round(float64(w.Deg)/45)) % 8
+	if idx < 0 {
+		return "Var"
+	}
 	return directions[idx]
 }
 

--- a/internal/weather/weather.go
+++ b/internal/weather/weather.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"net/http"
 	"net/url"
@@ -172,6 +173,12 @@ type Wind struct {
 	Speed float64 `json:"speed"`
 	Deg   int     `json:"deg"`
 	Gust  float64 `json:"gust"`
+}
+
+func (w Wind) CompassDirection() string {
+	directions := []string{"N", "NE", "E", "SE", "S", "SW", "W", "NW"}
+	idx := int(math.Round(float64(w.Deg)/45)) % 8
+	return directions[idx]
 }
 
 type Clouds struct {

--- a/internal/weather/weather.go
+++ b/internal/weather/weather.go
@@ -175,15 +175,6 @@ type Wind struct {
 	Gust  float64 `json:"gust"`
 }
 
-func (w Wind) CompassDirection() string {
-	directions := []string{"N", "NE", "E", "SE", "S", "SW", "W", "NW"}
-	idx := int(math.Round(float64(w.Deg)/45)) % 8
-	if idx < 0 {
-		return "Var"
-	}
-	return directions[idx]
-}
-
 type Clouds struct {
 	All int `json:"all"`
 }
@@ -299,6 +290,17 @@ func AddWeatherLocation(ctx context.Context, location config.WeatherLocation) {
 // AddWeatherLocationWithForecast adds a new location and enables periodic forecast updates.
 func AddWeatherLocationWithForecast(ctx context.Context, location config.WeatherLocation) {
 	addWeatherLocation(ctx, location, true)
+}
+
+// CompassDirection converts the wind direction in degrees to a cardinal or intercardinal direction string (N, NE, E, SE, S, SW, W, NW).
+// Returns "Var" if the degree value is outside the 0–360 range.
+func (w Wind) CompassDirection() string {
+	if w.Deg < 0 || w.Deg > 360 {
+        return "Var"
+    }
+	directions := []string{"N", "NE", "E", "SE", "S", "SW", "W", "NW"}
+	idx := int(math.Round(float64(w.Deg)/45)) % 8
+	return directions[idx]
 }
 
 // CurrentWeather retrieves the current weather data for a given location name.

--- a/internal/weather/weather_test.go
+++ b/internal/weather/weather_test.go
@@ -83,3 +83,32 @@ func TestComputeNext24hTempRange(t *testing.T) {
 		})
 	}
 }
+
+func TestWindCompassDirection(t *testing.T) {
+	tests := []struct {
+		name     string
+		degree   int
+		expected string
+	}{
+		{"North", 0, "N"},
+		{"NorthEast", 45, "NE"},
+		{"East", 90, "E"},
+		{"SouthEast", 135, "SE"},
+		{"South", 180, "S"},
+		{"SouthWest", 225, "SW"},
+		{"West", 270, "W"},
+		{"NorthWest", 315, "NW"},
+		{"North wrap", 338, "N"},
+		{"Negative degree", -45, "Var"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := Wind{Deg: tt.degree}
+			result := w.CompassDirection()
+			if result != tt.expected {
+				t.Errorf("CompassDirection() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/weather/weather_test.go
+++ b/internal/weather/weather_test.go
@@ -98,8 +98,11 @@ func TestWindCompassDirection(t *testing.T) {
 		{"SouthWest", 225, "SW"},
 		{"West", 270, "W"},
 		{"NorthWest", 315, "NW"},
+		{"North 360", 360, "N"},
 		{"North wrap", 338, "N"},
+		{"NW upper boundary", 337, "NW"},
 		{"Negative degree", -45, "Var"},
+		{"Overflow degree", 405, "Var"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Added a `wind_direction` config option that displays wind direction as a compass heading (N, NE, E, etc.) instead of degrees.

- **`internal/config/config.go`** — Added `WindDirection bool` to `WeatherLocationStatOptions`
- **`internal/weather/weather.go`** — Added `CompassDirection()` method on `Wind` (converts degrees to 8-point compass via `math.Round`)
- **`internal/templates/partials/weather.templ`** — Conditionally renders compass heading when `wind_direction: true`, degrees otherwise
- **`config.schema.json`** — Added `wind_direction` boolean property under `show`

The setting is independent of `wind: true/false` — it only changes *how* direction is displayed, not whether wind is shown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-location option to display wind direction as compass headings (N, NE, E, SE, S, SW, W, NW) instead of numeric degrees; disabled by default and preserves speed and units.
  * Configuration schema updated to include the new wind-direction toggle.

* **Tests**
  * Added unit tests covering compass-heading outputs for normal, boundary and invalid degree inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->