### PR TITLE
go v bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN bun run css && bun run js && bun run url-builder
 
 
 # Go Builder
-FROM --platform=$BUILDPLATFORM golang:1.26.2-bookworm AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.3-bookworm AS build
 
 ARG VERSION=demo
 ARG TARGETOS

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/damongolding/immich-kiosk
 
-go 1.26.2
+go 1.26.3
 
 require (
 	charm.land/lipgloss/v2 v2.0.3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain to version 1.26.3 across the build environment and project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->