### PR TITLE
keybind for fullscreen

### DIFF
--- a/frontend/src/ts/kiosk.ts
+++ b/frontend/src/ts/kiosk.ts
@@ -460,6 +460,12 @@ function addEventListeners(): void {
                 keyboardActionMute(e);
                 break;
 
+            case "KeyF":
+                if (!e.ctrlKey && !e.metaKey) {
+                    keyboardActionFullscreen(e);
+                }
+                break;
+
             case "ArrowUp":
                 handleCustomKeyboardAction(e, kioskData.upArrowAction);
                 break;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Press the F key to toggle fullscreen mode in the kiosk. This new keyboard shortcut enables users to quickly switch between fullscreen and windowed display modes, providing a convenient way to control the display without navigating through menus or interface options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/damongolding/immich-kiosk/pull/757?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->