### PR TITLE
Add hardcoded davening times overlay

### DIFF
--- a/frontend/src/css/davening-times.css
+++ b/frontend/src/css/davening-times.css
@@ -1,0 +1,87 @@
+#davening-times {
+    position: absolute;
+    right: 1rem;
+    bottom: 1rem;
+    z-index: var(--z-clock);
+    min-width: 13rem;
+    padding: 0.85rem 1rem;
+    color: #fff;
+    text-shadow: 0 0 1rem rgba(0, 0, 0, 0.7);
+    background: rgba(0, 0, 0, 0.42);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    border-radius: 1rem;
+    box-shadow: 0 0.75rem 2rem rgba(0, 0, 0, 0.22);
+    backdrop-filter: blur(0.75rem);
+    transition: opacity var(--burn-in-fade) ease-in-out;
+}
+
+.burn-in-dim #davening-times {
+    opacity: var(--burn-in-opacity);
+}
+
+.polling-paused.more-info,
+.polling-paused.redirects-open {
+    #davening-times {
+        opacity: 0.2;
+    }
+}
+
+.davening-times__title {
+    margin: 0 0 0.45rem;
+    font-size: 0.8rem;
+    font-weight: 700;
+    line-height: 1;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+    opacity: 0.86;
+}
+
+.davening-times__list {
+    display: grid;
+    gap: 0.35rem;
+    margin: 0;
+}
+
+.davening-times__row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1.5rem;
+}
+
+.davening-times__row dt,
+.davening-times__row dd {
+    margin: 0;
+}
+
+.davening-times__row dt {
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+.davening-times__row dd {
+    font-size: 1.1rem;
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+}
+
+@media screen and (max-width: 31.25rem) {
+    #davening-times {
+        right: 0.5rem;
+        bottom: 0.5rem;
+        min-width: 11.5rem;
+        padding: 0.7rem 0.8rem;
+    }
+
+    .davening-times__title {
+        font-size: 0.7rem;
+    }
+
+    .davening-times__row dt {
+        font-size: 0.9rem;
+    }
+
+    .davening-times__row dd {
+        font-size: 1rem;
+    }
+}

--- a/frontend/src/css/kiosk.css
+++ b/frontend/src/css/kiosk.css
@@ -13,6 +13,7 @@
 @import url("./clock-weather-container.css");
 @import url("./clock.css");
 @import url("./weather.css");
+@import url("./davening-times.css");
 @import url("./menu.css");
 @import url("./sleep.css");
 @import url("./video.css");

--- a/internal/templates/partials/davening_times.templ
+++ b/internal/templates/partials/davening_times.templ
@@ -1,0 +1,21 @@
+package partials
+
+templ DaveningTimes() {
+	<section id="davening-times" aria-label="Local shul davening times">
+		<h2 class="davening-times__title">Davening Times</h2>
+		<dl class="davening-times__list">
+			<div class="davening-times__row">
+				<dt>Shachris</dt>
+				<dd>8:00 AM</dd>
+			</div>
+			<div class="davening-times__row">
+				<dt>Mincha</dt>
+				<dd>8:30 PM</dd>
+			</div>
+			<div class="davening-times__row">
+				<dt>Maariv</dt>
+				<dd>9:00 PM</dd>
+			</div>
+		</dl>
+	</section>
+}

--- a/internal/templates/partials/partials_test.go
+++ b/internal/templates/partials/partials_test.go
@@ -1,7 +1,10 @@
 package partials
 
 import (
+	"bytes"
+	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/damongolding/immich-kiosk/internal/immich"
@@ -121,5 +124,30 @@ func TestTrimFloatToString(t *testing.T) {
 				t.Errorf("trimFloatToString(%f) = %s; expected %s", test.input, result, test.expected)
 			}
 		})
+	}
+}
+
+func TestDaveningTimesRendersHardcodedSchedule(t *testing.T) {
+	var rendered bytes.Buffer
+
+	err := DaveningTimes().Render(context.Background(), &rendered)
+	if err != nil {
+		t.Fatalf("DaveningTimes render failed: %v", err)
+	}
+
+	html := rendered.String()
+	for _, want := range []string{
+		`id="davening-times"`,
+		"Davening Times",
+		"Shachris",
+		"8:00 AM",
+		"Mincha",
+		"8:30 PM",
+		"Maariv",
+		"9:00 PM",
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("DaveningTimes() output missing %q in %s", want, html)
+		}
 	}
 }

--- a/internal/templates/views/views_home.templ
+++ b/internal/templates/views/views_home.templ
@@ -77,6 +77,7 @@ templ Home(viewData common.ViewData, secret string) {
 							}
 						</div>
 					</section>
+					@partials.DaveningTimes()
 				}
 				if !viewData.DisableNavigation {
 					@partials.Menu(viewData, viewData.Queries, secret)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added davening times overlay to the kiosk interface displaying three daily prayer times: Shachris (8:00 AM), Mincha (8:30 PM), and Maariv (9:00 PM).
  * Includes responsive styling optimised for both standard and small-screen displays.
  * Features burn-in fade transition effects for improved display longevity.

* **Tests**
  * Added testing to verify schedule display accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->