### PR TITLE
fix: handle rejected video.play() on resume so slideshow recovers (#652)

### DIFF
--- a/frontend/src/ts/polling.ts
+++ b/frontend/src/ts/polling.ts
@@ -179,7 +179,10 @@ class PollingController {
         if (!this.isPaused || this.animationFrameId !== null) return;
 
         if (this.currentProgressSource?.type === "video" && this.video) {
-            this.video.play();
+            this.video.play().catch((error) => {
+                console.error("Video playback error on resume:", error);
+                this.handleVideoError(error);
+            });
         } else {
             this.currentProgressSource = {
                 type: "image",


### PR DESCRIPTION
## Summary

Guards the `video.play()` call in `resumePolling()` (`frontend/src/ts/polling.ts`) with a `.catch` that routes failures to `handleVideoError`, mirroring the existing recovery pattern already used in `videoHandler`. When a resume `play()` rejects, the slideshow now cleans up and advances to the next asset instead of stalling.

## Why this matters

Issue #652: on Android (Fully Kiosk Browser / WebView), turning the screen off backgrounds the tab and Chromium pauses video-only background media. On wake, Kiosk calls `video.play()`, which rejects with:

```
AbortError: The play() request was interrupted because video-only background media was paused to save power.
```

As @arthursoares diagnosed in the issue, that rejected promise was unhandled. Because `updateProgress` derives video progress from `video.currentTime / video.duration`, a video that never starts playing produces a frozen progress value, so the asset never ends and the slideshow halts indefinitely until the page is reloaded.

The codebase already handles the same failure correctly in `videoHandler` (`.catch -> handleVideoError -> videoCleanup -> triggerNewAsset`). The `resumePolling` path simply omitted that guard. This change applies the existing pattern to the one unguarded call site.

## Testing

- `node_modules/.bin/tsc --noEmit` (task `frontend:typecheck`) passes.
- `node_modules/.bin/biome lint src/ts/polling.ts` passes.
- `esbuild` JS bundle build (task `frontend:js`) succeeds.
- The successful-resume path is unchanged; only a rejected `play()` now triggers graceful recovery.

Scope is intentionally limited to the single unguarded call site. A broader visibility-aware playback gate is left out to keep the change minimal and avoid overlapping with the separate live-photo polling rework in PR #586.

Fixes #652

AI was used for assistance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video playback reliability by enhancing error handling when resuming playback. The system now gracefully manages playback failures by logging errors and automatically advancing to the next item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->