### PR TITLE
Add favorite asset filter

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -60,6 +60,7 @@ memories: false # show memories
 
 ## Filters
 # filter_date: last-30-days # Limit assets from sources to a given date range
+# filter_favorites: false # Limit assets from sources to favorites.
 # filter_newest: 0 # Limit asset sources to only the newest X assets.
 # filter_exclude_faces: false # Excludes assets where Immich has detected a face
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -155,6 +155,10 @@
       "type": "string",
       "description": "Filter to limit assets to a certain date range"
     },
+    "filter_favorites": {
+      "type": "boolean",
+      "description": "Filter to limit assets to favorites"
+    },
     "filter_newest": {
       "type": "integer",
       "minimum": 0,

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -149,6 +149,7 @@ type URLBuilderRequest struct {
 	ExcludedPeople   []string `form:"excluded_people" url:"exclude_person,omitempty"`
 	Albums           []string `form:"albums" url:"album,omitempty"`
 	AlbumOrder       *string  `form:"album_order" url:"album_order,omitempty"`
+	FilterFavorites  *bool    `form:"filter_favorites" url:"filter_favorites,omitempty"`
 	ExcludedAlbums   []string `form:"excluded_albums" url:"exclude_album,omitempty"`
 	Tags             []string `form:"tags" url:"tag,omitempty"`
 	ExcludedTags     []string `form:"excluded_tags" url:"exclude_tag,omitempty"`

--- a/internal/common/url_builder_request_test.go
+++ b/internal/common/url_builder_request_test.go
@@ -35,6 +35,21 @@ func TestURLBuilderRequestEncodesWeatherFields(t *testing.T) {
 	assertQueryValue(t, values.Get("weather_round_temperature"), "true")
 }
 
+func TestURLBuilderRequestEncodesFilterFavorites(t *testing.T) {
+	req := URLBuilderRequest{
+		Albums:          []string{"album-1"},
+		FilterFavorites: ptr(true),
+	}
+
+	values, err := query.Values(req)
+	if err != nil {
+		t.Fatalf("encoding URL builder request: %v", err)
+	}
+
+	assertQueryValue(t, values.Get("album"), "album-1")
+	assertQueryValue(t, values.Get("filter_favorites"), "true")
+}
+
 func assertQueryValue(t *testing.T, actual string, expected string) {
 	t.Helper()
 	if actual != expected {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -344,6 +344,8 @@ type Config struct {
 
 	// FilterDate filter certain asset bucket assets by date range
 	FilterDate string `json:"filterDate" yaml:"filter_date" mapstructure:"filter_date" query:"filter_date" form:"filter_date" default:""`
+	// FilterFavorites filters asset buckets to favorite assets.
+	FilterFavorites bool `json:"filterFavorites" yaml:"filter_favorites" mapstructure:"filter_favorites" query:"filter_favorites" form:"filter_favorites" default:"false"`
 	// FilterNewest filter certain asset bucket assets by the newest X assets
 	FilterNewest int `json:"filterNewest" yaml:"filter_newest" mapstructure:"filter_newest" query:"filter_newest" form:"filter_newest" default:"0"`
 	// FilterExcludeFaces filter certain asset bucket assets by the presence of faces

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -172,6 +172,23 @@ func TestImmichURLImmichMultipleAlbum(t *testing.T) {
 	assert.Contains(t, configWithBaseOnly.Albums, "BASE_ALBUM_2", "BASE_ALBUM_2 should be present")
 }
 
+func TestFilterFavoritesURLOverride(t *testing.T) {
+	c := New()
+
+	e := echo.New()
+	q := make(url.Values)
+	q.Add("album", "ALBUM_1")
+	q.Add("filter_favorites", "true")
+
+	req := httptest.NewRequest(http.MethodGet, "/?"+q.Encode(), nil)
+	rec := httptest.NewRecorder()
+	echoContenx := e.NewContext(req, rec)
+
+	err := c.ConfigWithOverrides(echoContenx.QueryParams(), echoContenx)
+	assert.NoError(t, err, "ConfigWithOverrides should not return an error")
+	assert.True(t, c.FilterFavorites, "Expected filter_favorites to enable favorite filtering")
+}
+
 func TestAlbumAndPerson(t *testing.T) {
 	testCases := []struct {
 		name           string

--- a/internal/immich/immich.go
+++ b/internal/immich/immich.go
@@ -225,6 +225,7 @@ type SearchRandomBody struct {
 	Make          string   `url:"make,omitempty" json:"make,omitempty"`
 	Model         string   `url:"model,omitempty" json:"model,omitempty"`
 	Ocr           string   `url:"ocr,omitempty" json:"ocr,omitempty"`
+	Order         string   `url:"order,omitempty" json:"order,omitempty"`
 	State         string   `url:"state,omitempty" json:"state,omitempty"`
 	TakenAfter    string   `url:"takenAfter,omitempty" json:"takenAfter,omitempty"`
 	TakenBefore   string   `url:"takenBefore,omitempty" json:"takenBefore,omitempty"`

--- a/internal/immich/immich_album.go
+++ b/internal/immich/immich_album.go
@@ -178,6 +178,24 @@ func countAssetsInAlbums(albums Albums) int {
 	return total
 }
 
+// countAssetsInAlbums returns album asset counts, applying search-backed filters when needed.
+func (a *Asset) countAssetsInAlbums(albums Albums, requestID, deviceID string) (int, error) {
+	if !a.requestConfig.FilterFavorites {
+		return countAssetsInAlbums(albums), nil
+	}
+
+	total := 0
+	for _, album := range albums {
+		count, err := a.albumSearchAssetsCount(album.ID, requestID, deviceID)
+		if err != nil {
+			return 0, err
+		}
+		total += count
+	}
+
+	return total, nil
+}
+
 // AlbumImageCount retrieves the number of images in a specific album from Immich.
 // Parameters:
 //   - albumID: ID of the album to count images from, can be a special keyword
@@ -194,21 +212,21 @@ func (a *Asset) AlbumImageCount(albumID string, requestID, deviceID string) (int
 		if err != nil {
 			return 0, fmt.Errorf("get all albums (%s) err=%w", albumsURL, err)
 		}
-		return countAssetsInAlbums(albums), nil
+		return a.countAssetsInAlbums(albums, requestID, deviceID)
 
 	case kiosk.AlbumKeywordOwned:
 		albums, albumsURL, err := a.allOwnedAlbums(requestID, deviceID)
 		if err != nil {
 			return 0, fmt.Errorf("get owned albums (%s) err=%w", albumsURL, err)
 		}
-		return countAssetsInAlbums(albums), nil
+		return a.countAssetsInAlbums(albums, requestID, deviceID)
 
 	case kiosk.AlbumKeywordShared:
 		albums, albumsURL, err := a.allSharedAlbums(requestID, deviceID)
 		if err != nil {
 			return 0, fmt.Errorf("get shared albums (%s) err=%w", albumsURL, err)
 		}
-		return countAssetsInAlbums(albums), nil
+		return a.countAssetsInAlbums(albums, requestID, deviceID)
 
 	case kiosk.AlbumKeywordFavourites, kiosk.AlbumKeywordFavorites:
 		favouriteAssetCount, err := a.favouriteAssetsCount(requestID, deviceID)
@@ -218,6 +236,14 @@ func (a *Asset) AlbumImageCount(albumID string, requestID, deviceID string) (int
 		return favouriteAssetCount, nil
 
 	default:
+		if a.requestConfig.FilterFavorites {
+			filteredAssetCount, err := a.albumSearchAssetsCount(albumID, requestID, deviceID)
+			if err != nil {
+				return 0, fmt.Errorf("get filtered album assets for album %s: %w", albumID, err)
+			}
+			return filteredAssetCount, nil
+		}
+
 		album, _, err := a.albumAssets(albumID, requestID, deviceID)
 		if err != nil {
 			return 0, fmt.Errorf("get album assets for album %s: %w", albumID, err)
@@ -334,7 +360,7 @@ func (a *Asset) AssetFromAlbum(albumID string, albumAssetsOrder AssetOrder, requ
 // Parameters:
 //   - albums: List of albums to select from
 //   - excludedAlbums: List of album IDs to exclude from selection
-func (a *Asset) selectRandomAlbum(albums Albums, excludedAlbums []string) (string, error) {
+func (a *Asset) selectRandomAlbum(albums Albums, excludedAlbums []string, requestID, deviceID string) (string, error) {
 	albums.RemoveExcludedAlbums(excludedAlbums)
 	if len(albums) == 0 {
 		return "", errors.New("no albums available after applying exclusions")
@@ -342,10 +368,27 @@ func (a *Asset) selectRandomAlbum(albums Albums, excludedAlbums []string) (strin
 
 	albumsWithWeighting := []utils.AssetWithWeighting{}
 	for _, album := range albums {
+		weight := album.AssetCount
+		if a.requestConfig.FilterFavorites {
+			count, err := a.albumSearchAssetsCount(album.ID, requestID, deviceID)
+			if err != nil {
+				return "", err
+			}
+			weight = count
+		}
+
+		if weight == 0 {
+			continue
+		}
+
 		albumsWithWeighting = append(albumsWithWeighting, utils.AssetWithWeighting{
 			Asset:  utils.WeightedAsset{Type: kiosk.SourceAlbum, ID: album.ID},
-			Weight: album.AssetCount,
+			Weight: weight,
 		})
+	}
+
+	if len(albumsWithWeighting) == 0 {
+		return "", errors.New("no albums available after applying filters")
 	}
 
 	pickedAlbum := utils.PickRandomImageType(a.requestConfig.Kiosk.AssetWeighting, albumsWithWeighting)
@@ -362,7 +405,7 @@ func (a *Asset) RandomAlbumFromSharedAlbums(requestID, deviceID string, excluded
 		return "", err
 	}
 
-	return a.selectRandomAlbum(albums, excludedAlbums)
+	return a.selectRandomAlbum(albums, excludedAlbums, requestID, deviceID)
 }
 
 // RandomAlbumFromAllAlbums returns a random album ID from all albums.
@@ -375,7 +418,7 @@ func (a *Asset) RandomAlbumFromAllAlbums(requestID, deviceID string, excludedAlb
 		return "", err
 	}
 
-	return a.selectRandomAlbum(albums, excludedAlbums)
+	return a.selectRandomAlbum(albums, excludedAlbums, requestID, deviceID)
 }
 
 // RandomAlbumFromOwnedAlbums returns a random album ID from owned albums.
@@ -388,7 +431,7 @@ func (a *Asset) RandomAlbumFromOwnedAlbums(requestID, deviceID string, excludedA
 		return "", err
 	}
 
-	return a.selectRandomAlbum(albums, excludedAlbums)
+	return a.selectRandomAlbum(albums, excludedAlbums, requestID, deviceID)
 }
 
 // RemoveExcludedAlbums filters out albums whose IDs are in the exclude slice.

--- a/internal/immich/immich_date.go
+++ b/internal/immich/immich_date.go
@@ -76,6 +76,8 @@ func (a *Asset) RandomAssetInDateRange(dateRange, requestID, deviceID string, is
 			requestBody.WithArchived = true
 		}
 
+		FilterFavorites(&requestBody, a.requestConfig.FilterFavorites)
+
 		// convert body to queries so url is unique and can be cached
 		queries, _ := query.Values(requestBody)
 

--- a/internal/immich/immich_favourites.go
+++ b/internal/immich/immich_favourites.go
@@ -41,6 +41,42 @@ func (a *Asset) favouriteAssetsCount(requestID, deviceID string) (int, error) {
 	return a.fetchPaginatedMetadata(u, requestBody, requestID, deviceID)
 }
 
+// albumSearchAssetsCount counts assets in an album using the search API.
+func (a *Asset) albumSearchAssetsCount(albumID, requestID, deviceID string) (int, error) {
+	u, err := url.Parse(a.requestConfig.ImmichURL)
+	if err != nil {
+		_, _, err = immichAPIFail(0, err, nil, "")
+		return 0, err
+	}
+
+	requestBody := a.albumSearchBody(albumID)
+	requestBody.WithPeople = false
+	requestBody.WithExif = false
+
+	return a.fetchPaginatedMetadata(u, requestBody, requestID, deviceID)
+}
+
+// albumSearchBody builds a reusable search request scoped to a single album.
+func (a *Asset) albumSearchBody(albumID string) SearchRandomBody {
+	requestBody := SearchRandomBody{
+		AlbumIDs:   []string{albumID},
+		Type:       string(ImageType),
+		WithExif:   true,
+		WithPeople: true,
+		Size:       a.requestConfig.Kiosk.FetchedAssetsSize,
+	}
+
+	if a.requestConfig.ShowVideos {
+		requestBody.Type = ""
+	}
+
+	if a.requestConfig.ShowArchived {
+		requestBody.WithArchived = true
+	}
+
+	return requestBody
+}
+
 // RandomAssetFromFavourites retrieves a random favorite asset from the Immich server.
 // It makes an API request to get random favorite assets and caches them for future use.
 // The function includes retries if No viable assets are found and handles caching of
@@ -145,6 +181,74 @@ func (a *Asset) RandomAssetFromFavourites(requestID, deviceID string, isPrefetch
 	}
 
 	return errors.New("no assets found for favourites. Max retries reached")
+}
+
+// AssetFromAlbumSearch retrieves an album asset using search-backed filters and ordering.
+func (a *Asset) AssetFromAlbumSearch(albumID string, albumAssetsOrder AssetOrder, requestID, deviceID string) error {
+	for range MaxRetries {
+		requestBody := a.albumSearchBody(albumID)
+
+		switch albumAssetsOrder {
+		case Asc:
+			requestBody.Order = string(Asc)
+		case Desc:
+			requestBody.Order = string(Desc)
+		case Rand:
+		}
+
+		assets, apiURL, err := a.fetchAssets(requestID, deviceID, requestBody)
+		if err != nil {
+			return err
+		}
+
+		apiCacheKey := cache.APICacheKey(apiURL.String(), deviceID, a.requestConfig.SelectedUser)
+
+		if len(assets) == 0 {
+			log.Debug(requestID + " No filtered assets left in album cache. Refreshing and trying again")
+			cache.Delete(apiCacheKey)
+			continue
+		}
+
+		wantedAssetType := ImageOnlyAssetTypes
+		if a.requestConfig.ShowVideos {
+			wantedAssetType = AllAssetTypes
+		}
+
+		for assetIndex, asset := range assets {
+			asset.Bucket = kiosk.SourceAlbum
+			asset.requestConfig = a.requestConfig
+			asset.ctx = a.ctx
+
+			if !asset.isValidAsset(requestID, deviceID, wantedAssetType, a.RatioWanted) {
+				continue
+			}
+
+			if a.requestConfig.Kiosk.Cache {
+				assetsToCache := slices.Delete(assets, assetIndex, assetIndex+1)
+				jsonBytes, marshalErr := json.Marshal(assetsToCache)
+				if marshalErr != nil {
+					log.Error("Failed to marshal assetsToCache", "error", marshalErr)
+					return marshalErr
+				}
+
+				cache.Set(apiCacheKey, jsonBytes, a.requestConfig.Duration, a.requestConfig.CacheDuration)
+			}
+
+			asset.BucketID = albumID
+			if asset.requestConfig.SelectedUser != "" {
+				asset.BucketID = albumID + "@" + asset.requestConfig.SelectedUser
+			}
+
+			*a = asset
+
+			return nil
+		}
+
+		log.Debug(requestID + " No viable filtered assets left in album cache. Refreshing and trying again")
+		cache.Delete(apiCacheKey)
+	}
+
+	return errors.New("no filtered assets found for album. Max retries reached")
 }
 
 func (a *Asset) FavouriteStatus(deviceID string, favourite bool) error {

--- a/internal/immich/immich_filter.go
+++ b/internal/immich/immich_filter.go
@@ -23,3 +23,10 @@ func FilterDate(requestBody *SearchRandomBody, dateFilter string) {
 		requestBody.TakenBefore = dateEnd.Format(time.RFC3339)
 	}
 }
+
+// FilterFavorites applies favorite filtering to the search request body.
+func FilterFavorites(requestBody *SearchRandomBody, filterFavorites bool) {
+	if filterFavorites {
+		requestBody.IsFavorite = true
+	}
+}

--- a/internal/immich/immich_helpers.go
+++ b/internal/immich/immich_helpers.go
@@ -230,6 +230,7 @@ func (a *Asset) immichAPICall(ctx context.Context, method, apiURL string, body [
 // FilterNewest is applied here.
 func (a *Asset) fetchAssets(requestID, deviceID string, requestBody SearchRandomBody) ([]Asset, url.URL, error) {
 	filterNewest := a.requestConfig.FilterNewest > 0
+	useMetadataSearch := filterNewest || requestBody.Order != ""
 
 	var immichAssets []Asset
 
@@ -240,6 +241,7 @@ func (a *Asset) fetchAssets(requestID, deviceID string, requestBody SearchRandom
 	}
 
 	FilterDate(&requestBody, a.requestConfig.FilterDate)
+	FilterFavorites(&requestBody, a.requestConfig.FilterFavorites)
 
 	if filterNewest {
 		requestBody.Size = a.requestConfig.FilterNewest
@@ -248,7 +250,7 @@ func (a *Asset) fetchAssets(requestID, deviceID string, requestBody SearchRandom
 	queries, _ := query.Values(requestBody)
 
 	apiPath := "api/search/random"
-	if filterNewest {
+	if useMetadataSearch {
 		apiPath = "api/search/metadata"
 	}
 
@@ -266,19 +268,19 @@ func (a *Asset) fetchAssets(requestID, deviceID string, requestBody SearchRandom
 	}
 
 	var immichAPICall apiCall
-	if filterNewest {
+	if useMetadataSearch {
 		immichAPICall = withImmichAPICache(a.immichAPICall, requestID, deviceID, a.requestConfig, SearchMetadataResponse{})
 	} else {
 		immichAPICall = withImmichAPICache(a.immichAPICall, requestID, deviceID, a.requestConfig, []Asset{})
 	}
 
-	apiBody, _, usingCache, err := immichAPICall(a.ctx, http.MethodPost, apiURL.String(), jsonBody)
+	apiBody, _, _, err := immichAPICall(a.ctx, http.MethodPost, apiURL.String(), jsonBody)
 	if err != nil {
 		_, _, err = immichAPIFail(immichAssets, err, apiBody, apiURL.String())
 		return nil, url.URL{}, err
 	}
 
-	if filterNewest && !usingCache {
+	if useMetadataSearch {
 		var searchMetadataResponse SearchMetadataResponse
 		if err = json.Unmarshal(apiBody, &searchMetadataResponse); err != nil {
 			log.Error("failed Unmarshal", "err", err)
@@ -643,6 +645,7 @@ func (a *Asset) containsTag(tagValue string) bool {
 func (a *Asset) isValidAsset(requestID, deviceID string, allowedTypes []AssetType, wantedRatio ImageOrientation) bool {
 	return a.hasValidBasicProperties(allowedTypes, wantedRatio) &&
 		a.hasValidFilterDate() &&
+		a.hasValidFilterFavorites(requestID, deviceID) &&
 		a.hasValidPartners() &&
 		a.hasValidFilterExcludeFaces(requestID, deviceID) &&
 		a.hasValidAlbums(requestID, deviceID) &&
@@ -682,6 +685,23 @@ func (a *Asset) hasValidBasicProperties(allowedTypes []AssetType, wantedRatio Im
 		return false
 	}
 	return true
+}
+
+// hasValidFilterFavorites validates favorite-only filtering for assets from any source.
+func (a *Asset) hasValidFilterFavorites(requestID, deviceID string) bool {
+	if !a.requestConfig.FilterFavorites {
+		return true
+	}
+
+	if a.IsFavorite {
+		return true
+	}
+
+	if err := a.AssetInfo(requestID, deviceID); err != nil {
+		log.Error("Failed to get additional asset data", "error", err)
+	}
+
+	return a.IsFavorite
 }
 
 func (a *Asset) isAnimatedGif() bool {
@@ -851,6 +871,9 @@ func (a *Asset) hasValidTags(requestID, deviceID string) bool {
 
 func (a *Asset) fetchPaginatedMetadata(u *url.URL, requestBody SearchRandomBody, requestID string, deviceID string) (int, error) {
 	var totalCount int
+
+	FilterDate(&requestBody, a.requestConfig.FilterDate)
+	FilterFavorites(&requestBody, a.requestConfig.FilterFavorites)
 
 	for {
 

--- a/internal/immich/immich_person.go
+++ b/internal/immich/immich_person.go
@@ -141,6 +141,10 @@ func (a *Asset) PersonAssetCount(personID, requestID, deviceID string) (int, err
 		return a.allPeopleAssetCount(requestID, deviceID)
 	}
 
+	if a.requestConfig.FilterFavorites {
+		return a.personSearchAssetCount(personID, requestID, deviceID)
+	}
+
 	var personStatistics PersonStatistics
 
 	u, err := url.Parse(a.requestConfig.ImmichURL)
@@ -169,6 +173,38 @@ func (a *Asset) PersonAssetCount(personID, requestID, deviceID string) (int, err
 	}
 
 	return personStatistics.Assets, nil
+}
+
+// personSearchAssetCount counts person assets using the search API when filters are active.
+func (a *Asset) personSearchAssetCount(personID, requestID, deviceID string) (int, error) {
+	u, err := url.Parse(a.requestConfig.ImmichURL)
+	if err != nil {
+		_, _, err = immichAPIFail(0, err, nil, "")
+		return 0, err
+	}
+
+	requestBody := SearchRandomBody{
+		PersonIDs:  []string{personID},
+		Type:       string(ImageType),
+		WithPeople: false,
+		WithExif:   false,
+		Size:       a.requestConfig.Kiosk.FetchedAssetsSize,
+	}
+
+	if a.requestConfig.ShowVideos {
+		requestBody.Type = ""
+	}
+
+	if a.requestConfig.RequireAllPeople {
+		requestBody.PersonIDs = make([]string, len(a.requestConfig.People))
+		copy(requestBody.PersonIDs, a.requestConfig.People)
+	}
+
+	if a.requestConfig.ShowArchived {
+		requestBody.WithArchived = true
+	}
+
+	return a.fetchPaginatedMetadata(u, requestBody, requestID, deviceID)
 }
 
 // RandomAssetOfPerson retrieves a random asset for a given person from the Immich API.

--- a/internal/immich/immich_test.go
+++ b/internal/immich/immich_test.go
@@ -4,6 +4,7 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/damongolding/immich-kiosk/internal/config"
 	"github.com/damongolding/immich-kiosk/internal/kiosk"
 	"github.com/stretchr/testify/assert"
 )
@@ -54,6 +55,52 @@ func TestArchiveLogic(t *testing.T) {
 			assert.Equal(t, test.WantSimulatedContinue, simulatedContinueTriggered, "Unexpected simulatedContinueTriggered value")
 		})
 	}
+}
+
+func TestFilterFavorites(t *testing.T) {
+	requestBody := SearchRandomBody{}
+
+	FilterFavorites(&requestBody, true)
+
+	assert.True(t, requestBody.IsFavorite)
+}
+
+func TestAlbumSearchBody(t *testing.T) {
+	asset := Asset{
+		requestConfig: config.Config{
+			Kiosk: config.KioskSettings{
+				FetchedAssetsSize: 42,
+			},
+		},
+	}
+
+	requestBody := asset.albumSearchBody("album-id")
+
+	assert.Equal(t, []string{"album-id"}, requestBody.AlbumIDs)
+	assert.Equal(t, string(ImageType), requestBody.Type)
+	assert.False(t, requestBody.IsFavorite)
+	assert.True(t, requestBody.WithExif)
+	assert.True(t, requestBody.WithPeople)
+	assert.Equal(t, 42, requestBody.Size)
+	assert.False(t, requestBody.WithArchived)
+}
+
+func TestAlbumSearchBodyWithVideosAndArchived(t *testing.T) {
+	asset := Asset{
+		requestConfig: config.Config{
+			ShowVideos:   true,
+			ShowArchived: true,
+			Kiosk: config.KioskSettings{
+				FetchedAssetsSize: 100,
+			},
+		},
+	}
+
+	requestBody := asset.albumSearchBody("album-id")
+
+	assert.Empty(t, requestBody.Type)
+	assert.True(t, requestBody.WithArchived)
+	assert.False(t, requestBody.IsFavorite)
 }
 
 // TestFacesCenterPoint tests the calculation of the center point between detected faces in an asset

--- a/internal/routes/routes_asset_helpers.go
+++ b/internal/routes/routes_asset_helpers.go
@@ -308,9 +308,11 @@ func isSleepMode(requestConfig config.Config) bool {
 
 // retrieveImage fetches a random image based on the picked image type.
 // It returns an error if the image retrieval fails.
-func retrieveImage(immichAsset *immich.Asset, pickedAsset utils.WeightedAsset, albumOrder string, excludedAlbums []string, requestID, deviceID string, isPrefetch bool) error {
+func retrieveImage(immichAsset *immich.Asset, pickedAsset utils.WeightedAsset, albumOrder string, filterFavorites bool, excludedAlbums []string, requestID, deviceID string, isPrefetch bool) error {
 	switch pickedAsset.Type {
 	case kiosk.SourceAlbum:
+		useFilterFavorites := filterFavorites
+
 		switch pickedAsset.ID {
 		case kiosk.AlbumKeywordAll:
 			pickedAlbumID, err := immichAsset.RandomAlbumFromAllAlbums(requestID, deviceID, excludedAlbums)
@@ -331,15 +333,25 @@ func retrieveImage(immichAsset *immich.Asset, pickedAsset utils.WeightedAsset, a
 			}
 			pickedAsset.ID = pickedAlbumID
 		case kiosk.AlbumKeywordFavourites, kiosk.AlbumKeywordFavorites:
+			useFilterFavorites = false
 			return immichAsset.RandomAssetFromFavourites(requestID, deviceID, isPrefetch)
 		}
 
 		switch strings.ToLower(albumOrder) {
 		case config.AlbumOrderDescending, config.AlbumOrderDesc, config.AlbumOrderNewest:
+			if useFilterFavorites {
+				return immichAsset.AssetFromAlbumSearch(pickedAsset.ID, immich.Desc, requestID, deviceID)
+			}
 			return immichAsset.AssetFromAlbum(pickedAsset.ID, immich.Desc, requestID, deviceID)
 		case config.AlbumOrderAscending, config.AlbumOrderAsc, config.AlbumOrderOldest:
+			if useFilterFavorites {
+				return immichAsset.AssetFromAlbumSearch(pickedAsset.ID, immich.Asc, requestID, deviceID)
+			}
 			return immichAsset.AssetFromAlbum(pickedAsset.ID, immich.Asc, requestID, deviceID)
 		default:
+			if useFilterFavorites {
+				return immichAsset.AssetFromAlbumSearch(pickedAsset.ID, immich.Rand, requestID, deviceID)
+			}
 			return immichAsset.AssetFromAlbum(pickedAsset.ID, immich.Rand, requestID, deviceID)
 		}
 
@@ -414,7 +426,7 @@ func processAsset(asset *immich.Asset, requestConfig config.Config, requestID st
 
 		pickedAsset.ID, _ = asset.ApplyUserFromAssetID(pickedAsset.ID)
 
-		err = retrieveImage(asset, pickedAsset, requestConfig.AlbumOrder, requestConfig.ExcludedAlbums, requestID, deviceID, isPrefetch)
+		err = retrieveImage(asset, pickedAsset, requestConfig.AlbumOrder, requestConfig.FilterFavorites, requestConfig.ExcludedAlbums, requestID, deviceID, isPrefetch)
 		if err != nil {
 			continue
 		}

--- a/internal/templates/views/view_url_builder.templ
+++ b/internal/templates/views/view_url_builder.templ
@@ -137,6 +137,7 @@ templ URLBuilderForm(c config.Config, d common.URLViewData, extended bool) {
 					if extended {
 						@URLBuilderNumber("Past memory days", "past_memory_days", "Include memories from the last N days. 0 shows only today.", 0, 360, strconv.FormatInt(int64(c.PastMemoryDays), 10))
 						@URLBuilderRadio("Include archived", "show_archived", "Allow assets marked as archived to be displayed.", "true", "true", "false", "false")
+						@URLBuilderRadio("Filter favorites", "filter_favorites", "Only show favorite assets from selected sources.", "true", "true", "false", "false")
 					}
 					if extended {
 						// Video


### PR DESCRIPTION
## Summary
- add a filter_favorites option/query to show only favorite assets from selected sources
- apply favorite filtering through shared search paths for albums, people, tags, rating, random assets, and date ranges
- keep the existing album=favorites special keyword as global favorites
- expose the option in config schema, example config, and URL builder

## Notes
This follows maintainer feedback to make favorite filtering a general filter rather than an album-specific option. Immich search request DTOs already support isFavorite alongside other source filters such as albumIds, personIds, tagIds, and rating, so this keeps filtering server-side where possible.

## Testing
- CI=true go test ./...
- go build ./...
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optional "Filter favourites" setting to show only favourite assets from selected albums
  * URL builder added a "Filter favourites" control for easy configuration
  * Random/dated asset selection and album counts now respect the favourites filter

* **Tests**
  * Added unit tests covering favourites filtering, album search requests and URL encoding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->