### PR TITLE
fix: trigger new asset fetch when kiosk exits sleep mode

### DIFF
--- a/frontend/src/ts/sleep.ts
+++ b/frontend/src/ts/sleep.ts
@@ -1,5 +1,6 @@
 import fullyKiosk from "./fullykiosk";
 import immichFrame from "./immichframe";
+import { triggerNewAsset } from "./polling";
 
 /**
  * Enables or disables UI sleep mode and optionally controls the device screensaver state.
@@ -21,6 +22,7 @@ function sleepMode(
         document.body.classList.add("sleep");
     } else {
         document.body.classList.remove("sleep");
+        triggerNewAsset();
     }
 
     if (screensaver) {


### PR DESCRIPTION
## Summary

- When `sleepMode(false)` is called after the configured sleep window ends, `PollingController` was left in a stopped state - no image would load and the kiosk displayed only the spinner until the user tapped the screen
- Import `triggerNewAsset` from `./polling` in `sleep.ts` and call it in the `turnOn === false` branch; this calls `stopPolling()` to clear stale state, resets `lastPollTime`, then dispatches `kiosk-new-asset` on `#kiosk` - causing the polling loop to immediately fetch a new image and restart
- No changes to `polling.ts` or any Go/template files; `triggerNewAsset` was already exported

## Why this matters

Issue #669 reports that after the sleep window exits, the slideshow stalls indefinitely and only recovers on manual interaction. The root cause is that the HTMX sleep-poll mechanism calls `kiosk.sleepMode(false, ...)` which removed the `sleep` CSS class but never restarted the asset polling loop. This one-line addition in the `else` branch is the minimal fix.

Fixes #669


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where assets were not automatically refreshed when disabling sleep mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->