### PR TITLE
do not include other asset endpoint

### DIFF
--- a/frontend/src/ts/kiosk.ts
+++ b/frontend/src/ts/kiosk.ts
@@ -395,8 +395,8 @@ function addEventListeners(): void {
         const e = event as HTMXEvent;
         const path = e.detail?.pathInfo?.requestPath || "";
 
-        // Only restart polling for asset endpoints
-        if (path.startsWith("/asset/")) {
+        // Only restart polling for asset endpoints (new|offlie|previous)
+        if (!/^\/asset\/(new|offline|previous)$/.test(path)) {
             startPolling();
         }
     });
@@ -537,8 +537,8 @@ async function cleanupFrames(): Promise<void> {
 function setRequestLock(e: HTMXEvent): void {
     const path = e.detail?.pathInfo?.requestPath || "";
 
-    // Do not lock for non-asset requests (e.g. GIFS, live photos)
-    if (!path.startsWith("/asset/")) {
+    // Do not lock for non-asset requests (new|offline|previous)
+    if (!/^\/asset\/(new|offline|previous)$/.test(path)) {
         return;
     }
 

--- a/frontend/src/ts/kiosk.ts
+++ b/frontend/src/ts/kiosk.ts
@@ -396,7 +396,7 @@ function addEventListeners(): void {
         const path = e.detail?.pathInfo?.requestPath || "";
 
         // Only restart polling for asset endpoints (new|offlie|previous)
-        if (!/^\/asset\/(new|offline|previous)$/.test(path)) {
+        if (/^\/asset\/(new|offline|previous)$/.test(path)) {
             startPolling();
         }
     });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined asset request handling so polling restart and request-lock behaviour apply only to the relevant asset endpoints, improving precision without changing other request management behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->