### PR TITLE
fix: harden hide_cursor CSS so the cursor reliably disappears

### DIFF
--- a/internal/templates/partials/head.templ
+++ b/internal/templates/partials/head.templ
@@ -28,7 +28,12 @@ templ Head(viewData common.ViewData) {
 	<link rel="icon" type="image/png" sizes="16x16" href="/assets/images/favicon-16x16.png"/>
 	if viewData.HideCursor {
 		<style>
-			* {
+			html,
+			body,
+			*,
+			*::before,
+			*::after,
+			*:hover {
 			    cursor: none !important;
 			}
 		</style>


### PR DESCRIPTION
## Summary

Harden the CSS emitted when `hide_cursor` is enabled so the mouse cursor reliably disappears across browsers and elements.

## Why this matters

In #784 a user reports the mouse cursor stays visible in the upper-left of the kiosk display even with `hide_cursor` enabled. The on-main implementation in `internal/templates/partials/head.templ:31` emitted only `* { cursor: none !important; }`. That single rule can be defeated when an element re-asserts a cursor through a pseudo-element or on hover, and some engines do not treat `html`/`body` as covered by the universal selector in every case.

This change extends the existing `if viewData.HideCursor` style block to also target `html`, `body`, `*::before`, `*::after`, and `*:hover`, all with `cursor: none !important;`. It stays CSS-only and inside the existing guard, matching the direction of the `robust-cursor` development image already prototyped for this issue. No Go logic, config, or template-data changes.

## Testing

- `templ generate` regenerates the partial cleanly and the generated CSS contains the new selectors.
- `go vet ./internal/templates/partials/`
- `go build ./...`
- `go test ./internal/templates/partials/`

Fixes #784


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved cursor-hiding functionality to ensure consistent behaviour across all interface elements, pseudo-states, and interactive components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->