### PR TITLE
fix/album-order

### DIFF
--- a/internal/immich/immich.go
+++ b/internal/immich/immich.go
@@ -228,8 +228,7 @@ type Album struct {
 	LastModifiedAssetTimestamp string       `json:"lastModifiedAssetTimestamp"`
 
 	// Kiosk specific fields
-	Assets        []Asset `json:"assets"`
-	AssetsOrdered bool    `json:"assetsOrdered"`
+	Assets []Asset `json:"assets"`
 }
 
 type Albums []Album

--- a/internal/immich/immich.go
+++ b/internal/immich/immich.go
@@ -246,6 +246,7 @@ type SearchRandomBody struct {
 	Make          string   `url:"make,omitempty" json:"make,omitempty"`
 	Model         string   `url:"model,omitempty" json:"model,omitempty"`
 	Ocr           string   `url:"ocr,omitempty" json:"ocr,omitempty"`
+	Order         string   `url:"order,omitempty" json:"order,omitempty"`
 	State         string   `url:"state,omitempty" json:"state,omitempty"`
 	TakenAfter    string   `url:"takenAfter,omitempty" json:"takenAfter,omitempty"`
 	TakenBefore   string   `url:"takenBefore,omitempty" json:"takenBefore,omitempty"`

--- a/internal/immich/immich_album.go
+++ b/internal/immich/immich_album.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"path"
 	"slices"
+	"strings"
 
 	"charm.land/log/v2"
 
@@ -252,7 +253,6 @@ func (a *Asset) AlbumImageCount(albumID string, requestID, deviceID string) (int
 func (a *Asset) AssetFromAlbum(albumID string, requestID, deviceID string) error {
 	filterNewest := a.requestConfig.FilterNewest > 0
 	filterFavourites := a.requestConfig.FilterFavorites
-	albumAssetsOrder := AlbumOrder(a.requestConfig.AlbumOrder)
 	var apiCacheKey string
 
 	for range MaxRetries {
@@ -282,7 +282,7 @@ func (a *Asset) AssetFromAlbum(albumID string, requestID, deviceID string) error
 			album.Assets = album.Assets[:a.requestConfig.FilterNewest]
 		}
 
-		if albumAssetsOrder == Rand {
+		if strings.EqualFold(a.requestConfig.AlbumOrder, string(Rand)) {
 			rand.Shuffle(len(album.Assets), func(i, j int) {
 				album.Assets[i], album.Assets[j] = album.Assets[j], album.Assets[i]
 			})

--- a/internal/immich/immich_album.go
+++ b/internal/immich/immich_album.go
@@ -144,6 +144,11 @@ func (a *Asset) albumAssets(albumID, requestID, deviceID string, favoritesOnly b
 		Size:         a.requestConfig.Kiosk.FetchedAssetsSize,
 	}
 
+	assetOrder := AlbumOrder(a.requestConfig.AlbumOrder)
+	if assetOrder != Rand {
+		requestBody.Order = string(assetOrder)
+	}
+
 	// Include videos if show videos is enabled
 	if a.requestConfig.ShowVideos {
 		requestBody.Type = ""
@@ -244,9 +249,10 @@ func (a *Asset) AlbumImageCount(albumID string, requestID, deviceID string) (int
 // Returns:
 //   - error: Any error encountered during the asset retrieval process, including when No viable assets are found
 //     after maximum retry attempts
-func (a *Asset) AssetFromAlbum(albumID string, albumAssetsOrder AssetOrder, requestID, deviceID string) error {
+func (a *Asset) AssetFromAlbum(albumID string, requestID, deviceID string) error {
 	filterNewest := a.requestConfig.FilterNewest > 0
 	filterFavourites := a.requestConfig.FilterFavorites
+	albumAssetsOrder := AlbumOrder(a.requestConfig.AlbumOrder)
 	var apiCacheKey string
 
 	for range MaxRetries {
@@ -276,17 +282,10 @@ func (a *Asset) AssetFromAlbum(albumID string, albumAssetsOrder AssetOrder, requ
 			album.Assets = album.Assets[:a.requestConfig.FilterNewest]
 		}
 
-		switch albumAssetsOrder {
-		case Rand:
+		if albumAssetsOrder == Rand {
 			rand.Shuffle(len(album.Assets), func(i, j int) {
 				album.Assets[i], album.Assets[j] = album.Assets[j], album.Assets[i]
 			})
-		case Asc:
-			if !album.AssetsOrdered {
-				slices.Reverse(album.Assets)
-				album.AssetsOrdered = true
-			}
-		case Desc:
 		}
 
 		allowedTypes := ImageOnlyAssetTypes

--- a/internal/immich/immich_helpers.go
+++ b/internal/immich/immich_helpers.go
@@ -1024,3 +1024,14 @@ func (a *Asset) updateAsset(deviceID string, requestBody UpdateAssetBody) error 
 
 	return nil
 }
+
+func AlbumOrder(albumAssetsOrder string) AssetOrder {
+	switch albumAssetsOrder {
+	case config.AlbumOrderDescending, config.AlbumOrderDesc, config.AlbumOrderNewest:
+		return Desc
+	case config.AlbumOrderAscending, config.AlbumOrderAsc, config.AlbumOrderOldest:
+		return Asc
+	default:
+		return Rand
+	}
+}

--- a/internal/routes/routes_asset_helpers.go
+++ b/internal/routes/routes_asset_helpers.go
@@ -308,7 +308,7 @@ func isSleepMode(requestConfig config.Config) bool {
 
 // retrieveImage fetches a random image based on the picked image type.
 // It returns an error if the image retrieval fails.
-func retrieveImage(immichAsset *immich.Asset, pickedAsset utils.WeightedAsset, albumOrder string, excludedAlbums []string, requestID, deviceID string, isPrefetch bool) error {
+func retrieveImage(immichAsset *immich.Asset, pickedAsset utils.WeightedAsset, excludedAlbums []string, requestID, deviceID string, isPrefetch bool) error {
 	switch pickedAsset.Type {
 	case kiosk.SourceAlbum:
 		switch pickedAsset.ID {
@@ -334,14 +334,7 @@ func retrieveImage(immichAsset *immich.Asset, pickedAsset utils.WeightedAsset, a
 			return immichAsset.RandomAssetFromFavourites(requestID, deviceID, isPrefetch)
 		}
 
-		switch strings.ToLower(albumOrder) {
-		case config.AlbumOrderDescending, config.AlbumOrderDesc, config.AlbumOrderNewest:
-			return immichAsset.AssetFromAlbum(pickedAsset.ID, immich.Desc, requestID, deviceID)
-		case config.AlbumOrderAscending, config.AlbumOrderAsc, config.AlbumOrderOldest:
-			return immichAsset.AssetFromAlbum(pickedAsset.ID, immich.Asc, requestID, deviceID)
-		default:
-			return immichAsset.AssetFromAlbum(pickedAsset.ID, immich.Rand, requestID, deviceID)
-		}
+		return immichAsset.AssetFromAlbum(pickedAsset.ID, requestID, deviceID)
 
 	case kiosk.SourceDateRange:
 		return immichAsset.RandomAssetInDateRange(pickedAsset.ID, requestID, deviceID, isPrefetch)
@@ -414,7 +407,7 @@ func processAsset(asset *immich.Asset, requestConfig config.Config, requestID st
 
 		pickedAsset.ID, _ = asset.ApplyUserFromAssetID(pickedAsset.ID)
 
-		err = retrieveImage(asset, pickedAsset, requestConfig.AlbumOrder, requestConfig.ExcludedAlbums, requestID, deviceID, isPrefetch)
+		err = retrieveImage(asset, pickedAsset, requestConfig.ExcludedAlbums, requestID, deviceID, isPrefetch)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Album image selection now respects the configured album order when fetching assets.
  * Added support for sending an ordering option with random search requests.

* **Bug Fixes**
  * Improved album asset retrieval so random ordering is only applied when requested, making results more consistent with the selected sort order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->