### PR TITLE
Add Tempest (WeatherFlow) as a weather provider

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -125,11 +125,19 @@ show_more_info_qr_code: true
 like_button_action: favorite # album, favorite or both [album, favorite]
 hide_button_action: tag # tag, archive, or both [tag, archive]
 
-## Weather feature - you’ll need an API key from OpenWeatherMap
+## Weather feature - you’ll need an API key from OpenWeatherMap, or, for a Tempest
+## (WeatherFlow) personal weather station, a personal access token.
+## To get a Tempest access token: sign in at https://tempestwx.com, go to
+## Settings -> Data Authorizations -> Create Token. Your station_id can be found
+## in the Tempest app/website under your station's settings, or via the
+## /stations API endpoint (see https://apidocs.tempestwx.com).
+## Note: Tempest stations don't report visibility, so show.visibility has no
+## effect on tempest locations.
 # weather:
 #   rotation_interval: 60 # in seconds (minimum: 10); rotation must be enabled via URL parameter
 #   locations:
 #     - name: london
+#       type: openweathermap # openweathermap (default) or tempest
 #       lat: 51.5285262
 #       lon: -0.2663999
 #       api: ""
@@ -142,6 +150,18 @@ hide_button_action: tag # tag, archive, or both [tag, archive]
 #         wind: false
 #         wind_direction: false
 #         visibility: false
+#         temperature_range: false
+#     - name: home
+#       type: tempest
+#       station_id: ""
+#       api: "" # Tempest personal access token
+#       unit: metric
+#       forecast: false
+#       default: false
+#       show:
+#         humidity: false
+#         wind: false
+#         wind_direction: false
 #         temperature_range: false
 
 ## Add iframes into Kiosk - you can use local files or remote URLs

--- a/config.schema.json
+++ b/config.schema.json
@@ -417,17 +417,30 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["openweathermap", "tempest"],
+                "default": "openweathermap",
+                "description": "The weather data provider. 'tempest' requires station_id instead of lat/lon."
+              },
               "name": {
                 "type": "string"
               },
               "lat": {
-                "type": ["number", "string"]
+                "type": ["number", "string"],
+                "description": "Required when type is 'openweathermap' (or unset)"
               },
               "lon": {
-                "type": ["number", "string"]
+                "type": ["number", "string"],
+                "description": "Required when type is 'openweathermap' (or unset)"
+              },
+              "station_id": {
+                "type": "string",
+                "description": "Tempest station ID. Required when type is 'tempest'"
               },
               "api": {
-                "type": ["string", "null"]
+                "type": ["string", "null"],
+                "description": "OpenWeatherMap API key, or Tempest personal access token when type is 'tempest'"
               },
               "unit": {
                 "type": "string"
@@ -480,7 +493,7 @@
                 "type": "boolean"
               }
             },
-            "required": ["name", "lat", "lon"]
+            "required": ["name"]
           }
         }
       },

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,6 +66,9 @@ const (
 	apiKeyFileEnv        = "KIOSK_IMMICH_API_KEY_FILE"
 	passwordFileEnv      = "KIOSK_PASSWORD_FILE"
 	weatherAPIKeyFileEnv = "KIOSK_WEATHER_API_KEY_FILE"
+
+	// weatherProviderTempest is the WeatherLocation.Type value for Tempest (WeatherFlow) stations.
+	weatherProviderTempest = "tempest"
 )
 
 type OfflineMode struct {
@@ -164,10 +167,16 @@ type WeatherLocationStatOptions struct {
 	TemperatureRange bool `yaml:"temperature_range" mapstructure:"temperature_range" default:"false"`
 }
 
+// WeatherLocation configures a single weather data source. Type selects the provider
+// ("openweathermap", the default, or "tempest"). OpenWeatherMap locations use Lat/Lon
+// and API (the API key); Tempest locations use StationID and API (the personal access
+// token) instead.
 type WeatherLocation struct {
+	Type      string                     `yaml:"type" mapstructure:"type"`
 	Name      string                     `yaml:"name" mapstructure:"name" redact:"true"`
 	Lat       string                     `yaml:"lat" mapstructure:"lat" redact:"true"`
 	Lon       string                     `yaml:"lon" mapstructure:"lon" redact:"true"`
+	StationID string                     `yaml:"station_id" mapstructure:"station_id" redact:"true"`
 	API       string                     `yaml:"api" mapstructure:"api" redact:"true" msgpack:"-"`
 	Unit      string                     `yaml:"unit" mapstructure:"unit" redact:"true"`
 	Lang      string                     `yaml:"lang" mapstructure:"lang" redact:"true"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -298,6 +298,39 @@ func TestCheckWeatherLocations(t *testing.T) {
 			},
 			expected: "Weather location is missing required fields: latitude, longitude, API key",
 		},
+		{
+			name: "Tempest all fields present",
+			config: &Config{
+				Weather: WeatherConfig{
+					Locations: []WeatherLocation{
+						{Type: weatherProviderTempest, Name: "Home", StationID: "1234", API: "token123"},
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "Tempest missing station ID",
+			config: &Config{
+				Weather: WeatherConfig{
+					Locations: []WeatherLocation{
+						{Type: weatherProviderTempest, Name: "Home", API: "token123"},
+					},
+				},
+			},
+			expected: "Weather location is missing required fields: station ID",
+		},
+		{
+			name: "Tempest missing access token",
+			config: &Config{
+				Weather: WeatherConfig{
+					Locations: []WeatherLocation{
+						{Type: weatherProviderTempest, Name: "Home", StationID: "1234"},
+					},
+				},
+			},
+			expected: "Weather location is missing required fields: access token",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/config/config_validation.go
+++ b/internal/config/config_validation.go
@@ -311,14 +311,23 @@ func (c *Config) checkWeatherLocations() {
 		if w.Name == "" {
 			missingFields = append(missingFields, "name")
 		}
-		if w.Lat == "" {
-			missingFields = append(missingFields, "latitude")
-		}
-		if w.Lon == "" {
-			missingFields = append(missingFields, "longitude")
-		}
-		if w.API == "" {
-			missingFields = append(missingFields, "API key")
+		if w.Type == weatherProviderTempest {
+			if w.StationID == "" {
+				missingFields = append(missingFields, "station ID")
+			}
+			if w.API == "" {
+				missingFields = append(missingFields, "access token")
+			}
+		} else {
+			if w.Lat == "" {
+				missingFields = append(missingFields, "latitude")
+			}
+			if w.Lon == "" {
+				missingFields = append(missingFields, "longitude")
+			}
+			if w.API == "" {
+				missingFields = append(missingFields, "API key")
+			}
 		}
 		if w.Default {
 			if c.Weather.HasDefault {

--- a/internal/weather/tempest.go
+++ b/internal/weather/tempest.go
@@ -1,0 +1,247 @@
+package weather
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"charm.land/log/v2"
+)
+
+// TempestResponse mirrors the relevant parts of the Tempest (WeatherFlow) "better_forecast"
+// API response: https://apidocs.tempestwx.com/reference/get_better-forecast
+type TempestResponse struct {
+	CurrentConditions TempestCurrentConditions `json:"current_conditions"`
+	Forecast          TempestForecast          `json:"forecast"`
+	Timezone          string                   `json:"timezone"`
+}
+
+type TempestCurrentConditions struct {
+	Time             int64   `json:"time"`
+	Conditions       string  `json:"conditions"`
+	Icon             string  `json:"icon"`
+	AirTemperature   float64 `json:"air_temperature"`
+	RelativeHumidity int     `json:"relative_humidity"`
+	StationPressure  float64 `json:"station_pressure"`
+	WindAvg          float64 `json:"wind_avg"`
+	WindGust         float64 `json:"wind_gust"`
+	WindDirection    int     `json:"wind_direction"`
+}
+
+type TempestForecast struct {
+	Daily  []TempestForecastDaily  `json:"daily"`
+	Hourly []TempestForecastHourly `json:"hourly"`
+}
+
+type TempestForecastDaily struct {
+	DayStartLocal int64   `json:"day_start_local"`
+	Conditions    string  `json:"conditions"`
+	Icon          string  `json:"icon"`
+	AirTempHigh   float64 `json:"air_temp_high"`
+	AirTempLow    float64 `json:"air_temp_low"`
+}
+
+type TempestForecastHourly struct {
+	Time           int64   `json:"time"`
+	AirTemperature float64 `json:"air_temperature"`
+}
+
+// tempestAPIScheme and tempestAPIHost point at the Tempest REST API. They are
+// declared as vars (rather than consts) so tests can redirect requests to a
+// local httptest.Server.
+var (
+	tempestAPIScheme = "https"
+	tempestAPIHost   = "swd.weatherflow.com"
+)
+
+// fetchTempestData fetches current conditions and forecast data from the Tempest
+// "better_forecast" API for this location's station.
+func (w *Location) fetchTempestData(ctx context.Context) (*TempestResponse, error) {
+	apiURL := url.URL{
+		Scheme: tempestAPIScheme,
+		Host:   tempestAPIHost,
+		Path:   "swd/rest/better_forecast",
+	}
+
+	unitsTemp, unitsWind, unitsPressure, unitsPrecip, unitsDistance := "c", "mps", "mb", "mm", "km"
+	if strings.EqualFold(w.Unit, ImperialSystem) {
+		unitsTemp, unitsWind, unitsPressure, unitsPrecip, unitsDistance = "f", "mph", "inhg", "in", "mi"
+	}
+
+	q := url.Values{}
+	q.Set("station_id", w.StationID)
+	q.Set("token", w.API)
+	q.Set("units_temp", unitsTemp)
+	q.Set("units_wind", unitsWind)
+	q.Set("units_pressure", unitsPressure)
+	q.Set("units_precip", unitsPrecip)
+	q.Set("units_distance", unitsDistance)
+
+	apiURL.RawQuery = q.Encode()
+
+	// Prepare a redacted URL for logging (avoid leaking the access token)
+	apiURLForLog := apiURL
+	qLog := apiURLForLog.Query()
+	qLog.Set("token", "REDACTED")
+	apiURLForLog.RawQuery = qLog.Encode()
+
+	client := httpClient
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL.String(), nil)
+	if err != nil {
+		log.Error(err)
+		return nil, err
+	}
+
+	req.Header.Add("Accept", "application/json")
+
+	var res *http.Response
+	for attempt := range 3 {
+		res, err = client.Do(req)
+		if err == nil {
+			break
+		}
+		// Log attempts as 1-based for clarity
+		log.Error("Request failed, retrying", "attempt", attempt+1, "url", apiURLForLog.String(), "err", err)
+
+		backoff := time.Duration(1<<attempt) * time.Second
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(backoff):
+		}
+	}
+
+	if err != nil {
+		log.Error("Request failed after retries", "url", apiURLForLog.String(), "err", err)
+		return nil, err
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		bodyPreview, _ := io.ReadAll(io.LimitReader(res.Body, 1024))
+		err = fmt.Errorf("unexpected status code: %d, body: %s",
+			res.StatusCode, strings.TrimSpace(string(bodyPreview)))
+		log.Error("Tempest API error",
+			"url", apiURLForLog.String(),
+			"status", res.StatusCode,
+			"body", string(bodyPreview))
+		return nil, err
+	}
+
+	var result TempestResponse
+	if decErr := json.NewDecoder(res.Body).Decode(&result); decErr != nil {
+		log.Error("fetchTempestData", "err", decErr)
+		return nil, decErr
+	}
+
+	return &result, nil
+}
+
+// tempestIconToOWMID translates a Tempest forecast icon string into the equivalent
+// OpenWeatherMap numeric condition-code bucket used by weatherIcon in weather.templ.
+func tempestIconToOWMID(icon string) int {
+	switch icon {
+	case "cloudy", "partly-cloudy-day", "partly-cloudy-night":
+		return 804
+	case "foggy":
+		return 741
+	case "possibly-rainy-day", "possibly-rainy-night", "rainy":
+		return 500
+	case "possibly-sleet-day", "possibly-sleet-night", "sleet":
+		return 611
+	case "possibly-snow-day", "possibly-snow-night", "snow":
+		return 600
+	case "possibly-thunderstorm-day", "possibly-thunderstorm-night", "thunderstorm":
+		return 200
+	case "windy":
+		return 771
+	case "clear-day", "clear-night":
+		fallthrough
+	default:
+		return 800
+	}
+}
+
+// mapTempestCurrent converts a Tempest API response's current conditions into the
+// shared Weather struct consumed by the weather templates.
+func mapTempestCurrent(tr *TempestResponse) Weather {
+	cc := tr.CurrentConditions
+	return Weather{
+		Data: []Data{
+			{
+				Description: cc.Conditions,
+				ID:          tempestIconToOWMID(cc.Icon),
+			},
+		},
+		Main: Main{
+			Temp:     cc.AirTemperature,
+			Humidity: cc.RelativeHumidity,
+			Pressure: int(cc.StationPressure),
+		},
+		Wind: Wind{
+			Speed: cc.WindAvg,
+			Deg:   cc.WindDirection,
+			Gust:  cc.WindGust,
+		},
+		DT: cc.Time,
+	}
+}
+
+// mapTempestForecast converts a Tempest API response's forecast into the shared
+// ForecastData struct consumed by the weather templates.
+func mapTempestForecast(tr *TempestResponse) ForecastData {
+	n := min(3, len(tr.Forecast.Daily))
+	daily := make([]DailySummary, 0, n)
+	for _, d := range tr.Forecast.Daily[:n] {
+		date := time.Unix(d.DayStartLocal, 0)
+		daily = append(daily, DailySummary{
+			Date:        date,
+			DateStr:     date.Format("2006-01-02"),
+			MaxTemp:     d.AirTempHigh,
+			WeatherIcon: tempestIconToOWMID(d.Icon),
+		})
+	}
+
+	high, low := computeTempestNext24hTempRange(tr.Forecast.Hourly)
+
+	return ForecastData{
+		Daily:       daily,
+		Next24hHigh: high,
+		Next24hLow:  low,
+	}
+}
+
+// computeTempestNext24hTempRange scans the next 24 hours of hourly forecast entries
+// and returns the highest and lowest air temperature found.
+func computeTempestNext24hTempRange(hourly []TempestForecastHourly) (float64, float64) {
+	now := time.Now()
+	cutoff := now.Add(24 * time.Hour)
+
+	var high, low float64
+	initialized := false
+	for _, item := range hourly {
+		itemTime := time.Unix(item.Time, 0)
+		if itemTime.Before(now) || itemTime.After(cutoff) {
+			continue
+		}
+		if !initialized {
+			high = item.AirTemperature
+			low = item.AirTemperature
+			initialized = true
+		} else {
+			if item.AirTemperature > high {
+				high = item.AirTemperature
+			}
+			if item.AirTemperature < low {
+				low = item.AirTemperature
+			}
+		}
+	}
+	return high, low
+}

--- a/internal/weather/tempest_test.go
+++ b/internal/weather/tempest_test.go
@@ -1,0 +1,200 @@
+package weather
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+)
+
+// withTempestTestServer points the package's Tempest API host/scheme at a local
+// httptest.Server for the duration of fn, restoring the originals afterwards.
+func withTempestTestServer(t *testing.T, srv *httptest.Server, fn func()) {
+	t.Helper()
+
+	parsed, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("failed to parse test server URL: %v", err)
+	}
+
+	origScheme, origHost := tempestAPIScheme, tempestAPIHost
+	tempestAPIScheme, tempestAPIHost = parsed.Scheme, parsed.Host
+	defer func() { tempestAPIScheme, tempestAPIHost = origScheme, origHost }()
+
+	fn()
+}
+
+func TestTempestIconToOWMID(t *testing.T) {
+	tests := []struct {
+		icon string
+		want int
+	}{
+		{"clear-day", 800},
+		{"clear-night", 800},
+		{"cloudy", 804},
+		{"partly-cloudy-day", 804},
+		{"partly-cloudy-night", 804},
+		{"foggy", 741},
+		{"possibly-rainy-day", 500},
+		{"possibly-rainy-night", 500},
+		{"rainy", 500},
+		{"possibly-sleet-day", 611},
+		{"possibly-sleet-night", 611},
+		{"sleet", 611},
+		{"possibly-snow-day", 600},
+		{"possibly-snow-night", 600},
+		{"snow", 600},
+		{"possibly-thunderstorm-day", 200},
+		{"possibly-thunderstorm-night", 200},
+		{"thunderstorm", 200},
+		{"windy", 771},
+		{"some-unknown-icon", 800},
+		{"", 800},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.icon, func(t *testing.T) {
+			if got := tempestIconToOWMID(tc.icon); got != tc.want {
+				t.Errorf("tempestIconToOWMID(%q) = %d, want %d", tc.icon, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMapTempestCurrent(t *testing.T) {
+	tr := &TempestResponse{
+		CurrentConditions: TempestCurrentConditions{
+			Time:             1700000000,
+			Conditions:       "Partly Cloudy",
+			Icon:             "partly-cloudy-day",
+			AirTemperature:   21.5,
+			RelativeHumidity: 55,
+			StationPressure:  1013.2,
+			WindAvg:          3.4,
+			WindGust:         5.1,
+			WindDirection:    270,
+		},
+	}
+
+	got := mapTempestCurrent(tr)
+
+	if len(got.Data) != 1 {
+		t.Fatalf("expected 1 Data entry, got %d", len(got.Data))
+	}
+	if got.Data[0].Description != "Partly Cloudy" {
+		t.Errorf("Description = %q, want %q", got.Data[0].Description, "Partly Cloudy")
+	}
+	if got.Data[0].ID != 804 {
+		t.Errorf("ID = %d, want %d", got.Data[0].ID, 804)
+	}
+	if got.Main.Temp != 21.5 {
+		t.Errorf("Temp = %v, want %v", got.Main.Temp, 21.5)
+	}
+	if got.Main.Humidity != 55 {
+		t.Errorf("Humidity = %d, want %d", got.Main.Humidity, 55)
+	}
+	if got.Wind.Speed != 3.4 {
+		t.Errorf("Wind.Speed = %v, want %v", got.Wind.Speed, 3.4)
+	}
+	if got.Wind.Deg != 270 {
+		t.Errorf("Wind.Deg = %d, want %d", got.Wind.Deg, 270)
+	}
+	if got.DT != 1700000000 {
+		t.Errorf("DT = %d, want %d", got.DT, 1700000000)
+	}
+}
+
+func TestMapTempestForecast(t *testing.T) {
+	now := time.Now()
+	hour := func(offset float64) int64 {
+		return now.Add(time.Duration(offset * float64(time.Hour))).Unix()
+	}
+
+	tr := &TempestResponse{
+		Forecast: TempestForecast{
+			Daily: []TempestForecastDaily{
+				{DayStartLocal: hour(0), Conditions: "Clear", Icon: "clear-day", AirTempHigh: 25, AirTempLow: 12},
+				{DayStartLocal: hour(24), Conditions: "Rain", Icon: "rainy", AirTempHigh: 18, AirTempLow: 10},
+				{DayStartLocal: hour(48), Conditions: "Snow", Icon: "snow", AirTempHigh: 2, AirTempLow: -4},
+				{DayStartLocal: hour(72), Conditions: "Windy", Icon: "windy", AirTempHigh: 15, AirTempLow: 5},
+			},
+			Hourly: []TempestForecastHourly{
+				{Time: hour(-3), AirTemperature: 99}, // in the past, ignored
+				{Time: hour(1), AirTemperature: 20},
+				{Time: hour(6), AirTemperature: 25},
+				{Time: hour(12), AirTemperature: 8},
+				{Time: hour(25), AirTemperature: -99}, // beyond 24h, ignored
+			},
+		},
+	}
+
+	got := mapTempestForecast(tr)
+
+	if len(got.Daily) != 3 {
+		t.Fatalf("expected 3 daily summaries (capped), got %d", len(got.Daily))
+	}
+	if got.Daily[0].MaxTemp != 25 || got.Daily[0].WeatherIcon != 800 {
+		t.Errorf("Daily[0] = %+v, want MaxTemp=25 WeatherIcon=800", got.Daily[0])
+	}
+	if got.Daily[1].MaxTemp != 18 || got.Daily[1].WeatherIcon != 500 {
+		t.Errorf("Daily[1] = %+v, want MaxTemp=18 WeatherIcon=500", got.Daily[1])
+	}
+	if got.Daily[2].MaxTemp != 2 || got.Daily[2].WeatherIcon != 600 {
+		t.Errorf("Daily[2] = %+v, want MaxTemp=2 WeatherIcon=600", got.Daily[2])
+	}
+	if got.Next24hHigh != 25 {
+		t.Errorf("Next24hHigh = %v, want %v", got.Next24hHigh, 25)
+	}
+	if got.Next24hLow != 8 {
+		t.Errorf("Next24hLow = %v, want %v", got.Next24hLow, 8)
+	}
+}
+
+func TestFetchTempestData(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("station_id") != "1234" {
+				t.Errorf("station_id = %q, want %q", r.URL.Query().Get("station_id"), "1234")
+			}
+			if r.URL.Query().Get("token") != "secret-token" {
+				t.Errorf("token = %q, want %q", r.URL.Query().Get("token"), "secret-token")
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(TempestResponse{
+				CurrentConditions: TempestCurrentConditions{Conditions: "Clear", Icon: "clear-day", AirTemperature: 18},
+			})
+		}))
+		defer srv.Close()
+
+		withTempestTestServer(t, srv, func() {
+			loc := &Location{StationID: "1234", API: "secret-token", Unit: MetricSystem}
+
+			got, err := loc.fetchTempestData(context.Background())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.CurrentConditions.Conditions != "Clear" {
+				t.Errorf("Conditions = %q, want %q", got.CurrentConditions.Conditions, "Clear")
+			}
+		})
+	})
+
+	t.Run("non-200 status returns error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"status":{"status_code":401}}`))
+		}))
+		defer srv.Close()
+
+		withTempestTestServer(t, srv, func() {
+			loc := &Location{StationID: "1234", API: "bad-token", Unit: MetricSystem}
+
+			if _, err := loc.fetchTempestData(context.Background()); err == nil {
+				t.Fatal("expected error for non-200 status, got nil")
+			}
+		})
+	})
+}

--- a/internal/weather/weather.go
+++ b/internal/weather/weather.go
@@ -24,6 +24,8 @@ const (
 	MetricSystem                     = "metric"
 	ImperialSystem                   = "imperial"
 	APINameKeyword                   = "-api"
+	ProviderOpenWeatherMap           = "openweathermap"
+	ProviderTempest                  = "tempest"
 	WeatherRotation                  = "rotate"
 	WeatherParam                     = "weather"
 	WeatherRotationParam             = "weather_rotation"
@@ -117,9 +119,11 @@ type ForecastData struct {
 }
 
 type Location struct {
+	Type         string
 	Name         string
 	Lat          string
 	Lon          string
+	StationID    string
 	API          string
 	Unit         string
 	Lang         string
@@ -228,9 +232,11 @@ func addWeatherLocation(ctx context.Context, location config.WeatherLocation, wi
 	}
 
 	w := &Location{
+		Type:         location.Type,
 		Name:         location.Name,
 		Lat:          location.Lat,
 		Lon:          location.Lon,
+		StationID:    location.StationID,
 		API:          location.API,
 		Unit:         location.Unit,
 		Lang:         location.Lang,
@@ -407,9 +413,18 @@ func (w *Location) fetchWeatherData(ctx context.Context, endpoint string, result
 	return nil
 }
 
-// updateWeather fetches new weather data from the OpenWeatherMap API for this location.
+// updateWeather fetches new current-conditions data for this location from its configured provider.
 // Returns the updated Location and any error that occurred.
 func (w *Location) updateWeather(ctx context.Context) (Location, error) {
+	if w.Type == ProviderTempest {
+		tempestResp, err := w.fetchTempestData(ctx)
+		if err != nil {
+			return *w, err
+		}
+		w.Weather = mapTempestCurrent(tempestResp)
+		return *w, nil
+	}
+
 	var newWeather Weather
 	err := w.fetchWeatherData(ctx, "weather", &newWeather)
 	if err != nil {
@@ -419,9 +434,18 @@ func (w *Location) updateWeather(ctx context.Context) (Location, error) {
 	return *w, nil
 }
 
-// updateForecast fetches new forecast data from the OpenWeatherMap API for this location.
+// updateForecast fetches new forecast data for this location from its configured provider.
 // Returns the updated Location and any error that occurred.
 func (w *Location) updateForecast(ctx context.Context) (Location, error) {
+	if w.Type == ProviderTempest {
+		tempestResp, err := w.fetchTempestData(ctx)
+		if err != nil {
+			return *w, err
+		}
+		w.Forecast = mapTempestForecast(tempestResp)
+		return *w, nil
+	}
+
 	var newForecast Forecast
 	err := w.fetchWeatherData(ctx, "forecast", &newForecast)
 	if err != nil {


### PR DESCRIPTION
Adds a `type: tempest` option for weather locations alongside the existing OpenWeatherMap support. Tempest locations authenticate via a personal access token and station_id instead of lat/lon, and fetch current conditions + forecast from the better_forecast endpoint, mapped onto the existing shared weather/forecast model so no template changes were needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an additional weather provider, Tempest, alongside the existing provider.
  * Weather locations can now be configured with provider-specific settings, including station ID and access token.

* **Bug Fixes**
  * Improved validation so required weather settings now match the selected provider.
  * Updated weather data handling to return forecasts and current conditions correctly for both provider types.

* **Documentation**
  * Expanded the example configuration with Tempest setup guidance and sample settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->