### PR TITLE
feat: redirects grouping into categories

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -647,6 +647,9 @@
               "url": {
                 "type": "string"
               },
+              "category": {
+                "type": "string"
+              },
               "type": {
                 "type": "string"
               }

--- a/frontend/src/css/redirects.css
+++ b/frontend/src/css/redirects.css
@@ -90,20 +90,20 @@
     }
 
     .category-title {
+        padding: 1rem 0 0 0;
         margin: 0;
         margin-bottom: 0.5rem;
-        padding: 0;
         font-size: 1rem;
         font-weight: 600;
         color: rgba(255, 255, 255, 0.7);
-        text-transform: uppercase;
+        text-transform: capitalize;
         letter-spacing: 0.05em;
     }
 
     .redirect-category a {
-        padding-left: 3rem;
+        margin-left: 1.5rem;
         @media (max-width: 768px) {
-            padding-left: 1rem;
+            margin-left: 1rem;
         }
     }
 }

--- a/frontend/src/css/redirects.css
+++ b/frontend/src/css/redirects.css
@@ -84,6 +84,28 @@
         color: var(--cool-grey);
         background-color: var(--mint-green);
     }
+
+    .redirect-category {
+        margin-top: 1.5rem;
+    }
+
+    .category-title {
+        margin: 0;
+        margin-bottom: 0.5rem;
+        padding: 0;
+        font-size: 1rem;
+        font-weight: 600;
+        color: rgba(255, 255, 255, 0.7);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+    }
+
+    .redirect-category a {
+        padding-left: 3rem;
+        @media (max-width: 768px) {
+            padding-left: 1rem;
+        }
+    }
 }
 
 /* .frameless */

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -89,6 +89,8 @@ type Redirect struct {
 	URL string `yaml:"url" mapstructure:"url" redact:"true"`
 	// Type specifies the redirect behaviour (e.g., "internal", "external")
 	Type string `yaml:"type" mapstructure:"type"`
+	// Category: an optional category for grouping redirects
+	Category string `yaml:"category" mapstructure:"category"`
 }
 
 type KioskSettings struct {

--- a/internal/templates/partials/redirects.templ
+++ b/internal/templates/partials/redirects.templ
@@ -31,18 +31,20 @@ func groupRedirects(redirects []config.Redirect) []RedirectGroup {
 	for _, r := range redirects {
 		if r.Category == "" {
 			noCategoryGroup.Redirects = append(noCategoryGroup.Redirects, r)
-		} else {
-			idx, exists := categoryMap[r.Category]
-			if !exists {
-				groups = append(groups, RedirectGroup{
-					Category:  r.Category,
-					Redirects: []config.Redirect{r},
-				})
-				categoryMap[r.Category] = len(groups) - 1
-			} else {
-				groups[idx].Redirects = append(groups[idx].Redirects, r)
-			}
+			continue
 		}
+
+		idx, exists := categoryMap[r.Category]
+		if !exists {
+			groups = append(groups, RedirectGroup{
+				Category:  r.Category,
+				Redirects: []config.Redirect{r},
+			})
+			categoryMap[r.Category] = len(groups) - 1
+		} else {
+			groups[idx].Redirects = append(groups[idx].Redirects, r)
+		}
+
 	}
 
 	if len(noCategoryGroup.Redirects) > 0 {

--- a/internal/templates/partials/redirects.templ
+++ b/internal/templates/partials/redirects.templ
@@ -17,23 +17,72 @@ func checkAuthParam(queries url.Values) (bool, string, string) {
 	return false, "", ""
 }
 
+type RedirectGroup struct {
+	Category  string
+	Redirects []config.Redirect
+}
+
+func groupRedirects(redirects []config.Redirect) []RedirectGroup {
+	var groups []RedirectGroup
+	categoryMap := make(map[string]int)
+
+	noCategoryGroup := RedirectGroup{Category: ""}
+
+	for _, r := range redirects {
+		if r.Category == "" {
+			noCategoryGroup.Redirects = append(noCategoryGroup.Redirects, r)
+		} else {
+			idx, exists := categoryMap[r.Category]
+			if !exists {
+				groups = append(groups, RedirectGroup{
+					Category:  r.Category,
+					Redirects: []config.Redirect{r},
+				})
+				categoryMap[r.Category] = len(groups) - 1
+			} else {
+				groups[idx].Redirects = append(groups[idx].Redirects, r)
+			}
+		}
+	}
+
+	if len(noCategoryGroup.Redirects) > 0 {
+		return append([]RedirectGroup{noCategoryGroup}, groups...)
+	}
+
+	return groups
+}
+
+templ RedirectList(redirects []config.Redirect, hasPassword bool, password, paramType string) {
+    for _, redirect := range redirects {
+        {{ redirectName, _ := strings.CutPrefix(redirect.Name, "/") }}
+        if hasPassword {
+            <a href={ templ.SafeURL(fmt.Sprintf("/%s?%s=%s", redirectName, paramType, password)) }>{ redirectName }</a>
+        } else {
+            <a href={ templ.SafeURL(fmt.Sprintf("/%s", redirectName)) }>{ redirectName }</a>
+        }
+    }
+}
+
 templ Redirects(redirects []config.Redirect, queries url.Values) {
-	{{ hasPassword, password, paramType := checkAuthParam(queries) }}
-	<div id="redirects-container">
-		<div class="redirects">
-			<div class="redirects--shadow">
-				if hasPassword {
-					<a href={ templ.SafeURL("/?" + paramType + "=" + password) }>Home</a>
-				}
-				for _ , redirect := range redirects {
-					{{ redirectName, _ := strings.CutPrefix(redirect.Name, "/") }}
-					if hasPassword {
-						<a href={ templ.SafeURL(fmt.Sprintf("/%s?%s=%s", redirectName, paramType, password)) }>{ redirectName }</a>
-					} else {
-						<a href={ templ.SafeURL(fmt.Sprintf("/%s", redirectName)) }>{ redirectName }</a>
-					}
-				}
-			</div>
-		</div>
-	</div>
+    {{ hasPassword, password, paramType := checkAuthParam(queries) }}
+    {{ groupedRedirects := groupRedirects(redirects) }}
+    <div id="redirects-container">
+        <div class="redirects">
+            <div class="redirects--shadow">
+                if hasPassword {
+                    <a href={ templ.SafeURL("/?" + paramType + "=" + password) }>Home</a>
+                }
+                for _, group := range groupedRedirects {
+                    if group.Category == "" {
+                        @RedirectList(group.Redirects, hasPassword, password, paramType)
+                    } else {
+                        <div class="redirect-category">
+                            <h3 class="category-title">{ group.Category }</h3>
+                            @RedirectList(group.Redirects, hasPassword, password, paramType)
+                        </div>
+                    }
+                }
+            </div>
+        </div>
+    </div>
 }


### PR DESCRIPTION
Hello,

I'm adding the option to group your redirects by categories. It gives more options for organization.

Example, with the demo:
```yaml
  redirects:
    - name: curated
      url: /?weather=rotate
      category: "Themes"

    - name: bubble-theme
      url: /?weather=rotate&theme=bubble
      category: "Themes"

    - name: solid-theme
      url: /?weather=rotate&theme=solid
      category: "Themes"

    - name: random
      url: /?album=none&use_offline_mode=false&image_effect_amount=200

    - name: simple
      url: /?image_effect=none&layout=single&image_fit=contain&transition=none&disable_ui=true&show_more_info=false&use_offline_mode=false
      category: "Single"
```

Gives the following:
<img width="711" height="490" alt="image" src="https://github.com/user-attachments/assets/41e75ddf-2159-45e4-9edf-a8430d2b2cb0" />

I would love your feedback!
Cheers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redirects can now be assigned optional categories.
  * Categorised redirects are grouped under labelled sections, while uncategorised links remain at the top.
  * Category labels and links have been styled for clearer navigation across desktop and mobile screens.
  * Existing authentication parameters and the Home link continue to work as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->