### PR TITLE
fix url-builder extended/basic options links dropping password

### DIFF
--- a/internal/templates/views/view_url_builder.templ
+++ b/internal/templates/views/view_url_builder.templ
@@ -2,6 +2,7 @@ package views
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/damongolding/immich-kiosk/internal/common"
 	"github.com/damongolding/immich-kiosk/internal/config"
@@ -16,6 +17,16 @@ import (
 )
 
 type ChoicesOptions map[string]any
+
+// urlBuilderNavLink returns path unchanged if no password is set, otherwise
+// appends the password as a query param so navigating between the basic and
+// extended url-builder pages doesn't drop authentication.
+func urlBuilderNavLink(path, password string) string {
+	if password == "" {
+		return path
+	}
+	return path + "?password=" + url.QueryEscape(password)
+}
 
 func weatherLocationOptions(locations []config.WeatherLocation) []string {
 	var options []string
@@ -56,9 +67,9 @@ templ URLBuilderForm(c config.Config, d common.URLViewData, extended bool) {
 			<div class="content">
 				<h1>{ t("url_builder") }</h1>
 				if !extended {
-					<a href="/url-builder/extended" class="extended-link">{ t("extended_options") }</a>
+					<a href={ templ.SafeURL(urlBuilderNavLink("/url-builder/extended", c.Kiosk.Password)) } class="extended-link">{ t("extended_options") }</a>
 				} else {
-					<a href="/url-builder" class="extended-link">{ t("basic_options") }</a>
+					<a href={ templ.SafeURL(urlBuilderNavLink("/url-builder", c.Kiosk.Password)) } class="extended-link">{ t("basic_options") }</a>
 				}
 				<form
 					id="url-builder-form"


### PR DESCRIPTION
**Issue Description**:
Currently with kiosk password protection enabled, the "View extended options" link (and "Basic options" link back) on the url builder page are plain \<a href\> navigation links that dont carry the password. Clicking either link drops the query param entirely and shows an Unauthorized page

**Fix Description**:
This change adds a urlBuilderNavLink helper that appends ?password=<password> (URL-escaped) to both links when a password is configured. This follows the same convention already used elsewhere in the app for propagating a password across navigations (redirects.templ)

**Testing**:
I tested this locally by rebuilding via docker build and confirming "View extended options" and "Basic options" now navigate successfully instead of hitting the Unauthorized page. Additionally confirmed both links are unaffected and no query param is added when no password is configured

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL handling by safely encoding links.
  * Preserved the kiosk password when navigating between basic and extended URL-builder pages.
  * Added smoother navigation between URL-builder views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->