### PR TITLE
Support special keywords in exclude_album (owned, shared, favorites)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -37,6 +37,8 @@ albums:
 album_order: random # random | newest | oldest
 # Album IDs to exclude from being shown. Albums in this list will be filtered from
 # appearing in the frame even if they are included in the 'album' list.
+# Also supports the special keywords "all", "owned", "shared" and "favorites"/"favourites"
+# to exclude entire categories of albums/assets, in addition to specific album IDs.
 excluded_albums:
   - "ALBUM_ID"
 

--- a/internal/immich/immich_album.go
+++ b/internal/immich/immich_album.go
@@ -407,6 +407,71 @@ func (a *Asset) RandomAlbumFromOwnedAlbums(requestID, deviceID string, excludedA
 	return a.selectRandomAlbum(albums, excludedAlbums)
 }
 
+// ExcludedAlbumIDs resolves the configured ExcludedAlbums list, expanding any
+// special keywords ("all", "owned", "shared") into the concrete IDs of the
+// albums they represent. Literal album IDs are passed through unchanged.
+// The "favorites"/"favourites" keyword is not an album and is dropped here;
+// it is handled separately via per-asset favorite filtering.
+//
+// Parameters:
+//   - requestID: ID used for tracking API call chain
+//   - deviceID: ID of device making the request
+//
+// Returns:
+//   - []string: resolved list of excluded album IDs
+//   - error: any error encountered while expanding keywords
+func (a *Asset) ExcludedAlbumIDs(requestID, deviceID string) ([]string, error) {
+	excluded := a.requestConfig.ExcludedAlbums
+	if len(excluded) == 0 {
+		return excluded, nil
+	}
+
+	resolved := make([]string, 0, len(excluded))
+	var errs error
+
+	for _, id := range excluded {
+		switch id {
+		case kiosk.AlbumKeywordAll:
+			albums, albumsURL, err := a.allAlbums(requestID, deviceID)
+			if err != nil {
+				errs = errors.Join(errs, fmt.Errorf("expand excluded album keyword 'all' (%s): %w", albumsURL, err))
+				continue
+			}
+			for _, album := range albums {
+				resolved = append(resolved, album.ID)
+			}
+
+		case kiosk.AlbumKeywordOwned:
+			albums, albumsURL, err := a.allOwnedAlbums(requestID, deviceID)
+			if err != nil {
+				errs = errors.Join(errs, fmt.Errorf("expand excluded album keyword 'owned' (%s): %w", albumsURL, err))
+				continue
+			}
+			for _, album := range albums {
+				resolved = append(resolved, album.ID)
+			}
+
+		case kiosk.AlbumKeywordShared:
+			albums, albumsURL, err := a.allSharedAlbums(requestID, deviceID)
+			if err != nil {
+				errs = errors.Join(errs, fmt.Errorf("expand excluded album keyword 'shared' (%s): %w", albumsURL, err))
+				continue
+			}
+			for _, album := range albums {
+				resolved = append(resolved, album.ID)
+			}
+
+		case kiosk.AlbumKeywordFavourites, kiosk.AlbumKeywordFavorites:
+			continue
+
+		default:
+			resolved = append(resolved, id)
+		}
+	}
+
+	return resolved, errs
+}
+
 // RemoveExcludedAlbums filters out albums whose IDs are in the exclude slice.
 func (a *Albums) RemoveExcludedAlbums(exclude []string) {
 	if len(exclude) == 0 {

--- a/internal/immich/immich_album.go
+++ b/internal/immich/immich_album.go
@@ -27,24 +27,33 @@ import (
 //   - deviceID: ID of device making the request
 //
 // Results:
-//   - AppearsIn field of the ImmichAsset is updated with list of albums
-//   - Any error during API calls is logged but function does not return an error
-func (a *Asset) AlbumsThatContainAsset(requestID, deviceID string) {
+//   - AppearsIn field of the ImmichAsset is updated with whatever album
+//     memberships were successfully retrieved
+//   - error: any error(s) encountered fetching owned or shared memberships,
+//     joined together. Callers that rely on AppearsIn being complete (e.g.
+//     album exclusion checks) must treat a non-nil error as membership being
+//     unknown, since AppearsIn may be missing owned and/or shared albums.
+func (a *Asset) AlbumsThatContainAsset(requestID, deviceID string) error {
 	var albumsContainingAsset Albums
+	var errs error
 
 	owned, _, ownedErr := a.albums(requestID, deviceID, false, a.ID, false)
 	if ownedErr != nil {
 		log.Error("Failed to get owned albums containing asset", "err", ownedErr)
+		errs = errors.Join(errs, fmt.Errorf("get owned albums containing asset: %w", ownedErr))
 	}
 	albumsContainingAsset = append(albumsContainingAsset, owned...)
 
 	shared, _, sharedErr := a.albums(requestID, deviceID, true, a.ID, false)
 	if sharedErr != nil {
 		log.Error("Failed to get shared albums containing asset", "err", sharedErr)
+		errs = errors.Join(errs, fmt.Errorf("get shared albums containing asset: %w", sharedErr))
 	}
 	albumsContainingAsset = append(albumsContainingAsset, shared...)
 
 	a.AppearsIn = albumsContainingAsset
+
+	return errs
 }
 
 // albums retrieves albums from Immich based on the shared parameter.

--- a/internal/immich/immich_album.go
+++ b/internal/immich/immich_album.go
@@ -19,25 +19,30 @@ import (
 	"github.com/damongolding/immich-kiosk/internal/utils"
 )
 
-// AlbumsThatContainAsset finds all albums that contain this asset and updates
-// the AppearsIn field with the list of albums. The asset must have its ID set.
+// AlbumsThatContainAsset finds all albums that contain this asset, both owned
+// and shared, and updates the AppearsIn field with the combined list of
+// albums. The asset must have its ID set.
 // Parameters:
 //   - requestID: ID used for tracking API call chain
 //   - deviceID: ID of device making the request
 //
 // Results:
 //   - AppearsIn field of the ImmichAsset is updated with list of albums
-//   - Any error during API call is logged but function does not return an error
+//   - Any error during API calls is logged but function does not return an error
 func (a *Asset) AlbumsThatContainAsset(requestID, deviceID string) {
 	var albumsContainingAsset Albums
 
-	albums, _, err := a.albums(requestID, deviceID, false, a.ID, false)
-	if err != nil {
-		log.Error("Failed to get albums containing asset", "err", err)
-		return
+	owned, _, ownedErr := a.albums(requestID, deviceID, false, a.ID, false)
+	if ownedErr != nil {
+		log.Error("Failed to get owned albums containing asset", "err", ownedErr)
 	}
+	albumsContainingAsset = append(albumsContainingAsset, owned...)
 
-	albumsContainingAsset = append(albumsContainingAsset, albums...)
+	shared, _, sharedErr := a.albums(requestID, deviceID, true, a.ID, false)
+	if sharedErr != nil {
+		log.Error("Failed to get shared albums containing asset", "err", sharedErr)
+	}
+	albumsContainingAsset = append(albumsContainingAsset, shared...)
 
 	a.AppearsIn = albumsContainingAsset
 }

--- a/internal/immich/immich_helpers.go
+++ b/internal/immich/immich_helpers.go
@@ -754,12 +754,21 @@ func (a *Asset) hasValidAlbums(requestID, deviceID string) bool {
 	}
 
 	if len(a.AppearsIn) == 0 {
-		a.AlbumsThatContainAsset(requestID, deviceID)
+		if membershipErr := a.AlbumsThatContainAsset(requestID, deviceID); membershipErr != nil {
+			// AppearsIn may be missing owned and/or shared memberships, so we
+			// can't safely say the asset isn't in an excluded album. Fail
+			// closed rather than risk leaking an excluded asset through.
+			log.Error("determining album membership for exclusion check", "err", membershipErr)
+			return false
+		}
 	}
 
 	excludedAlbumIDs, err := a.ExcludedAlbumIDs(requestID, deviceID)
 	if err != nil {
+		// Same reasoning: an incomplete excluded-album list could wrongly
+		// allow an asset through, so fail closed here too.
 		log.Error("resolving excluded album keywords", "err", err)
+		return false
 	}
 
 	return !slices.ContainsFunc(a.AppearsIn, func(album Album) bool {

--- a/internal/immich/immich_helpers.go
+++ b/internal/immich/immich_helpers.go
@@ -647,6 +647,7 @@ func (a *Asset) isValidAsset(requestID, deviceID string, allowedTypes []AssetTyp
 		a.hasValidFilterDate() &&
 		a.hasValidPartners() &&
 		a.hasValidFilterExcludeFaces(requestID, deviceID) &&
+		a.hasValidExcludedFavorites() &&
 		a.hasValidAlbums(requestID, deviceID) &&
 		a.hasValidPeople(requestID, deviceID) &&
 		a.hasValidTags(requestID, deviceID)
@@ -737,7 +738,9 @@ func (a *Asset) hasValidFilterExcludeFaces(requestID, deviceID string) bool {
 }
 
 // hasValidAlbums checks if the asset belongs to any excluded albums.
-// If album data is missing, it fetches it first.
+// If album data is missing, it fetches it first. Special keywords in
+// ExcludedAlbums (e.g. "all", "owned", "shared") are expanded to their
+// underlying album IDs before the check is made.
 //
 // Parameters:
 //   - requestID: Unique identifier for the request
@@ -746,12 +749,37 @@ func (a *Asset) hasValidFilterExcludeFaces(requestID, deviceID string) bool {
 // Returns:
 //   - bool: true if asset is not in any excluded albums, false otherwise
 func (a *Asset) hasValidAlbums(requestID, deviceID string) bool {
+	if len(a.requestConfig.ExcludedAlbums) == 0 {
+		return true
+	}
+
 	if len(a.AppearsIn) == 0 {
 		a.AlbumsThatContainAsset(requestID, deviceID)
 	}
 
+	excludedAlbumIDs, err := a.ExcludedAlbumIDs(requestID, deviceID)
+	if err != nil {
+		log.Error("resolving excluded album keywords", "err", err)
+	}
+
 	return !slices.ContainsFunc(a.AppearsIn, func(album Album) bool {
-		return slices.Contains(a.requestConfig.ExcludedAlbums, album.ID)
+		return slices.Contains(excludedAlbumIDs, album.ID)
+	})
+}
+
+// hasValidExcludedFavorites checks if the asset should be excluded because
+// ExcludedAlbums contains the "favorites"/"favourites" keyword and the asset
+// is marked as a favorite.
+//
+// Returns:
+//   - bool: true if the asset is not a favorite, or favorites are not excluded
+func (a *Asset) hasValidExcludedFavorites() bool {
+	if !a.IsFavorite {
+		return true
+	}
+
+	return !slices.ContainsFunc(a.requestConfig.ExcludedAlbums, func(id string) bool {
+		return id == kiosk.AlbumKeywordFavourites || id == kiosk.AlbumKeywordFavorites
 	})
 }
 

--- a/internal/immich/immich_test.go
+++ b/internal/immich/immich_test.go
@@ -1,9 +1,14 @@
 package immich
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"slices"
 	"testing"
 
+	"github.com/damongolding/immich-kiosk/internal/config"
 	"github.com/damongolding/immich-kiosk/internal/kiosk"
 	"github.com/stretchr/testify/assert"
 )
@@ -215,6 +220,89 @@ func TestRemoveExcludedAlbums(t *testing.T) {
 			albums := tt.albums
 			albums.RemoveExcludedAlbums(tt.exclude)
 			assert.Equal(t, tt.expected, albums, "RemoveExcludedAlbums returned unexpected result")
+		})
+	}
+}
+
+// TestExcludedAlbumIDs tests that special keywords in ExcludedAlbums ("all",
+// "owned", "shared", "favorites"/"favourites") are correctly expanded into
+// concrete album IDs, while literal album IDs are passed through unchanged.
+func TestExcludedAlbumIDs(t *testing.T) {
+	ownedAlbums := Albums{{ID: "owned-1"}, {ID: "owned-2"}}
+	sharedAlbums := Albums{{ID: "shared-1"}}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var albums Albums
+		if r.URL.Query().Get("isShared") == "true" {
+			albums = sharedAlbums
+		} else {
+			albums = ownedAlbums
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		err := json.NewEncoder(w).Encode(albums)
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	newAsset := func(excludedAlbums []string) *Asset {
+		return &Asset{
+			ctx: context.Background(),
+			requestConfig: config.Config{
+				ImmichURL:      server.URL,
+				ExcludedAlbums: excludedAlbums,
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		exclude  []string
+		expected []string
+	}{
+		{
+			name:     "empty list",
+			exclude:  []string{},
+			expected: []string{},
+		},
+		{
+			name:     "literal album IDs pass through",
+			exclude:  []string{"literal-1", "literal-2"},
+			expected: []string{"literal-1", "literal-2"},
+		},
+		{
+			name:     "owned keyword expands to owned album IDs",
+			exclude:  []string{kiosk.AlbumKeywordOwned},
+			expected: []string{"owned-1", "owned-2"},
+		},
+		{
+			name:     "shared keyword expands to shared album IDs",
+			exclude:  []string{kiosk.AlbumKeywordShared},
+			expected: []string{"shared-1"},
+		},
+		{
+			name:     "all keyword expands to owned and shared album IDs",
+			exclude:  []string{kiosk.AlbumKeywordAll},
+			expected: []string{"owned-1", "owned-2", "shared-1"},
+		},
+		{
+			name:     "favorites and favourites keywords are dropped",
+			exclude:  []string{kiosk.AlbumKeywordFavorites, kiosk.AlbumKeywordFavourites},
+			expected: []string{},
+		},
+		{
+			name:     "keywords and literal IDs can be combined",
+			exclude:  []string{"literal-1", kiosk.AlbumKeywordShared},
+			expected: []string{"literal-1", "shared-1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			asset := newAsset(tt.exclude)
+			got, err := asset.ExcludedAlbumIDs("requestID", "deviceID")
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, tt.expected, got, "ExcludedAlbumIDs returned unexpected result")
 		})
 	}
 }

--- a/internal/immich/immich_test.go
+++ b/internal/immich/immich_test.go
@@ -334,9 +334,39 @@ func TestAlbumsThatContainAsset_SharedOnlyMembership(t *testing.T) {
 		},
 	}
 
-	asset.AlbumsThatContainAsset("requestID", "deviceID")
+	err := asset.AlbumsThatContainAsset("requestID", "deviceID")
+	assert.NoError(t, err)
 
 	assert.ElementsMatch(t, Albums{sharedAlbum}, asset.AppearsIn, "AlbumsThatContainAsset should include shared-only album membership")
+}
+
+// TestHasValidAlbums_FailsClosedOnMembershipLookupError tests that an asset
+// is treated as excluded (rather than let through) when part of its album
+// membership can't be determined, so a transient API error can't be used to
+// bypass exclude_album.
+func TestHasValidAlbums_FailsClosedOnMembershipLookupError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("isShared") == "true" {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		err := json.NewEncoder(w).Encode(Albums{})
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	asset := &Asset{
+		ID:  "asset-1",
+		ctx: context.Background(),
+		requestConfig: config.Config{
+			ImmichURL:      server.URL,
+			ExcludedAlbums: []string{"some-album"},
+		},
+	}
+
+	assert.False(t, asset.hasValidAlbums("requestID", "deviceID"), "hasValidAlbums should fail closed when album membership can't be fully determined")
 }
 
 func TestExtractDays(t *testing.T) {

--- a/internal/immich/immich_test.go
+++ b/internal/immich/immich_test.go
@@ -307,6 +307,38 @@ func TestExcludedAlbumIDs(t *testing.T) {
 	}
 }
 
+// TestAlbumsThatContainAsset_SharedOnlyMembership tests that AppearsIn is
+// populated from shared albums even when the asset has no owned album
+// memberships. This ensures per-asset filtering (e.g. exclude_album=shared
+// or exclude_album=all) can see shared-only album membership.
+func TestAlbumsThatContainAsset_SharedOnlyMembership(t *testing.T) {
+	sharedAlbum := Album{ID: "shared-album-1"}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		albums := Albums{}
+		if r.URL.Query().Get("isShared") == "true" {
+			albums = Albums{sharedAlbum}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		err := json.NewEncoder(w).Encode(albums)
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	asset := &Asset{
+		ID:  "asset-1",
+		ctx: context.Background(),
+		requestConfig: config.Config{
+			ImmichURL: server.URL,
+		},
+	}
+
+	asset.AlbumsThatContainAsset("requestID", "deviceID")
+
+	assert.ElementsMatch(t, Albums{sharedAlbum}, asset.AppearsIn, "AlbumsThatContainAsset should include shared-only album membership")
+}
+
 func TestExtractDays(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/routes/routes_asset_helpers.go
+++ b/internal/routes/routes_asset_helpers.go
@@ -407,7 +407,12 @@ func processAsset(asset *immich.Asset, requestConfig config.Config, requestID st
 
 		pickedAsset.ID, _ = asset.ApplyUserFromAssetID(pickedAsset.ID)
 
-		err = retrieveImage(asset, pickedAsset, requestConfig.ExcludedAlbums, requestID, deviceID, isPrefetch)
+		excludedAlbumIDs, excludedAlbumsErr := asset.ExcludedAlbumIDs(requestID, deviceID)
+		if excludedAlbumsErr != nil {
+			log.Error(requestID+" resolving excluded album keywords", "err", excludedAlbumsErr)
+		}
+
+		err = retrieveImage(asset, pickedAsset, excludedAlbumIDs, requestID, deviceID, isPrefetch)
 		if err != nil {
 			continue
 		}

--- a/internal/routes/routes_previous_asset.go
+++ b/internal/routes/routes_previous_asset.go
@@ -234,7 +234,9 @@ func getHistoryAsset(requestConfig config.Config, com *common.Common, requestID,
 		asset.AddRatio()
 
 		if requestConfig.ShowAlbumName {
-			asset.AlbumsThatContainAsset(requestID, deviceID)
+			if membershipErr := asset.AlbumsThatContainAsset(requestID, deviceID); membershipErr != nil {
+				log.Error(fmt.Errorf("get albums containing asset: %w", membershipErr))
+			}
 		}
 
 		var imgString, imgBlurString string


### PR DESCRIPTION
## Summary
- The `exclude_album` query/config param previously only matched literal album IDs. The `album` param already supports the special keywords `all`, `owned`, `shared` and `favorites`/`favourites`, but excluding by these categories had no effect.
- Added `Asset.ExcludedAlbumIDs`, which expands `owned`/`shared`/`all` keywords in `ExcludedAlbums` into the concrete album IDs they represent (via the existing owned/shared/all album lookups), used wherever excluded albums are evaluated (album selection and per-asset album-membership filtering).
- Added `hasValidExcludedFavorites`, which excludes favorite assets when `exclude_album` contains `favorites`/`favourites` (favorites aren't an album, so they're handled as a direct per-asset check rather than via album ID matching).
- Documented the new keyword support in `config.example.yaml`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/immich/...` (added `TestExcludedAlbumIDs` covering `all`/`owned`/`shared`/`favorites`/`favourites` expansion, literal IDs, and combinations)
- [x] `go test ./...` (pre-existing failure in `internal/routes` reproduces identically on `main`, unrelated to this change — it fails locally due to missing Immich URL config, not this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GetAQPyrsWxdnaSJYBZdcN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Album exclusion settings support `all`, `owned`, and `shared` for matching album categories.
  * `favorites` and `favourites` can exclude favourite assets.
  * Exclusions are resolved automatically when processing assets, including albums discovered at runtime.

* **Bug Fixes**
  * Assets now correctly show shared album memberships.
  * Album filtering fails safely when membership information cannot be retrieved.

* **Documentation**
  * Expanded configuration guidance to describe supported exclusion keywords and album IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->